### PR TITLE
Default use_bias to False in TabFM config

### DIFF
--- a/tabfm/src/tabfm_v1_0_0.py
+++ b/tabfm/src/tabfm_v1_0_0.py
@@ -60,7 +60,7 @@ class Config:
   y_embedding_scheme: YEmbeddingScheme = (
       YEmbeddingScheme.ADD_Y_TO_X_POST_EMBEDDING
   )
-  use_bias: bool = True
+  use_bias: bool = False
 
   def to_dict(self) -> Dict[str, Any]:
     return {


### PR DESCRIPTION
Flips the default of use_bias in the Config dataclass from True to False ...