### PR TITLE
Add CODEOWNERS for default reviewers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Default owners for everything in the repo.
+# These users are automatically requested for review on all pull requests.
+* @abhidas @siriuz42 @rajatsen91 @erzel @weihaokong


### PR DESCRIPTION
Adds a CODEOWNERS file so PRs auto-request review from the repo maintainers (@abhidas, @rajatsen91, @erzel, @weihaokong).