### PR TITLE
Declare runtime dependencies in pyproject.toml

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,13 @@ cd tabfm
 pip install -e .
 ```
 
+The base install uses CPU-only JAX. For GPU execution, install the `cuda`
+extra to pull the CUDA 12 plugin and NVIDIA libraries:
+
+```bash
+pip install -e .[cuda]
+```
+
 ### Requirements
 For a complete list of pinned dependencies and versions, please see [requirements.txt](requirements.txt). The core requirements are:
 *   Python >= 3.10

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,22 @@ keywords = []
 
 # pip dependencies of the project
 # Installed locally with `pip install -e .`
-dependencies = []
+# Pinned versions for the full reproducible environment are in requirements.txt.
+dependencies = [
+    "absl-py",
+    "chex",
+    "einops",
+    "flax",
+    "jax",
+    "jaxlib",
+    "jaxtyping",
+    "numpy",
+    "optax",
+    "orbax-checkpoint",
+    "pandas",
+    "scikit-learn",
+    "huggingface-hub",
+]
 
 # `version` is automatically set by flit to use `tabfm.__version__`
 dynamic = ["version"]
@@ -34,6 +49,13 @@ dev = [
     "pytest-xdist",
     "pylint>=2.6.0",
     "pyink",
+]
+
+# GPU support. The base `jax`/`jaxlib` deps are CPU-only; install this extra
+# (`pip install tabfm[cuda]`) to pull the CUDA 12 plugin + NVIDIA libraries for
+# GPU execution. Kept optional so CPU-only / macOS / CI installs stay light.
+cuda = [
+    "jax[cuda12]",
 ]
 
 [tool.pyink]


### PR DESCRIPTION
## Problem
`requirements.txt` lists the runtime dependencies, but `pyproject.toml`'s `[project].dependencies` was empty. CI installs with `pip install -e .[dev]`, which reads `pyproject.toml` (not `requirements.txt`), so no runtime deps were installed and `pytest` failed at collection with `ModuleNotFoundError: No module named 'absl'`.

## Fix
Declare the direct runtime dependencies (`absl-py`, `chex`, `einops`, `flax`, `jax`, `jaxlib`, `jaxtyping`, `numpy`, `optax`, `orbax-checkpoint`, `pandas`, `scikit-learn`, `huggingface-hub`) in `pyproject.toml`. `requirements.txt` is retained as the pinned, fully-reproducible environment.