### PR TITLE
Encode class labels alphabetically (sklearn convention)

### DIFF
--- a/tabfm/src/classifier_and_regressor.py
+++ b/tabfm/src/classifier_and_regressor.py
@@ -84,6 +84,8 @@ class CategoricalOrdinalEncoder(BaseEstimator, TransformerMixin):
         data (original behaviour).
       - ``"frequency"``: categories are sorted by descending frequency, so
         the most common category receives index 0.
+      - ``"alphabetical"``: categories are sorted ascending (alphabetically),
+        matching scikit-learn's ``LabelEncoder`` convention.
   """
 
   categories_: List[np.ndarray]
@@ -148,6 +150,10 @@ class CategoricalOrdinalEncoder(BaseEstimator, TransformerMixin):
         uniques = [u for u in uniques if str(u) != "nan"]
         # Filter rare categories
         uniques = [u for u in uniques if u not in rare_cats]
+        if self.mode == "alphabetical":
+          # Sort categories so encoding matches sklearn's LabelEncoder
+          # convention (classes ordered ascending / alphabetically).
+          uniques = sorted(uniques)
 
       self.categories_.append(np.array(uniques))
 
@@ -1472,8 +1478,8 @@ class TabFMClassifier(ClassifierMixin, BaseEstimator):
     """
     check_classification_targets(y)
 
-    # Encode class labels
-    self.y_encoder_ = CategoricalOrdinalEncoder(dtype=np.int64)
+    # Encode class labels (sorted/alphabetical to match sklearn convention)
+    self.y_encoder_ = CategoricalOrdinalEncoder(dtype=np.int64, mode="alphabetical")
     # Reshape for CategoricalOrdinalEncoder
     y_2d = y.reshape(-1, 1) if isinstance(y, np.ndarray) else np.array(y).reshape(-1, 1)
     y_encoded = self.y_encoder_.fit_transform(y_2d)

--- a/tabfm/src/classifier_and_regressor.py
+++ b/tabfm/src/classifier_and_regressor.py
@@ -128,32 +128,34 @@ class CategoricalOrdinalEncoder(BaseEstimator, TransformerMixin):
       counts = pd.Series(col).value_counts()
       rare_cats = counts[counts < self.min_frequency].index
 
+      # Determine the candidate categories in the order dictated by the mode.
       if self.mode == "frequency":
-        # Sort by descending frequency; ties broken by appearance order via
-        # stable sort (value_counts preserves insertion order for equal counts
-        # only in pandas >= 1.1 with sort=True, so we use the counts index
-        # directly which is already frequency-sorted).
-        uniques_sorted = counts.index.tolist()
-        # Filter NaNs and string "nan"
-        uniques = [
-            u
-            for u in uniques_sorted
-            if not pd.isna(u) and str(u) != "nan" and u not in rare_cats
-        ]
+        # Descending frequency. value_counts is already frequency-sorted, with
+        # ties broken by appearance order via pandas' stable sort.
+        candidates = counts.index.tolist()
+      elif self.mode == "appearance":
+        # Order of first appearance.
+        candidates = pd.unique(col)
+      elif self.mode == "alphabetical":
+        # Order of first appearance; sorted below once NaNs are removed.
+        candidates = pd.unique(col)
       else:
-        # Default: order of appearance
-        uniques = pd.unique(col)
-        # Filter NaNs
-        mask = ~pd.isna(uniques)
-        uniques = uniques[mask]
-        # Filter string "nan" if present to match TF behavior
-        uniques = [u for u in uniques if str(u) != "nan"]
-        # Filter rare categories
-        uniques = [u for u in uniques if u not in rare_cats]
-        if self.mode == "alphabetical":
-          # Sort categories so encoding matches sklearn's LabelEncoder
-          # convention (classes ordered ascending / alphabetically).
-          uniques = sorted(uniques)
+        raise ValueError(
+            f"Unknown mode: {self.mode!r}. Expected one of 'appearance', "
+            "'alphabetical', or 'frequency'."
+        )
+
+      # Drop NaNs, the literal string "nan" (to match TF behavior), and rare
+      # categories.
+      uniques = [
+          u
+          for u in candidates
+          if not pd.isna(u) and str(u) != "nan" and u not in rare_cats
+      ]
+      if self.mode == "alphabetical":
+        # Sort categories so encoding matches sklearn's LabelEncoder convention
+        # (classes ordered ascending / alphabetically).
+        uniques = sorted(uniques)
 
       self.categories_.append(np.array(uniques))
 


### PR DESCRIPTION
Add an `"alphabetical"` mode to `CategoricalOrdinalEncoder` (sort categories ascending) and use it for the label encoder, so `TabFMClassifier.classes_` and `predict_proba` column order follow scikit-learn's `LabelEncoder` convention (classes sorted ascending) instead of order-of-appearance.