### PR TITLE
Inference perf: checkpoint cache, selectable ICL attention, 128-padding

### DIFF
--- a/tabfm/src/classifier_and_regressor.py
+++ b/tabfm/src/classifier_and_regressor.py
@@ -1645,8 +1645,24 @@ class TabFMClassifier(ClassifierMixin, BaseEstimator):
     cat_masks_iter = cat_masks_split if cat_masks is not None else [None] * len(Xs_split)
     for X_batch, y_batch, cat_mask_batch in zip(Xs_split, ys_split, cat_masks_iter):
       orig_batch_size = X_batch.shape[0]
+      orig_seq_len = X_batch.shape[1]
+
+      # Follow prefill(): pad sequence length T (n_row) to a multiple of 128
+      # with -100. Padded rows fall past train_size and are sliced off below.
+      # Done here (outside the jit boundary) so varying dataset sizes bucket to
+      # the same padded shape, avoiding a recompile per distinct length.
+      _block_size = 128
+      _T_full = X_batch.shape[1]
+      _pad_len = ((_T_full - 1) // _block_size + 1) * _block_size - _T_full
+      if _pad_len > 0:
+        X_batch = np.pad(
+            X_batch, ((0, 0), (0, _pad_len), (0, 0)), constant_values=-100.0
+        )
+
       X_batch = _pad_batch_to_multiple_of(X_batch, num_data_shards)
       y_batch = _pad_batch_to_multiple_of(y_batch, num_data_shards)
+      if cat_mask_batch is not None:
+        cat_mask_batch = _pad_batch_to_multiple_of(cat_mask_batch, num_data_shards)
 
       X_batch = jax.device_put(jnp.array(X_batch, dtype=jnp.float32), data_sharding)
       y_batch = jax.device_put(jnp.array(y_batch, dtype=jnp.float32), data_sharding)
@@ -1668,11 +1684,8 @@ class TabFMClassifier(ClassifierMixin, BaseEstimator):
             constant_values=-100.0,
         )
 
-
-
       # No gradient calculation needed for inference
       if cat_mask_batch is not None and hasattr(self.model, "cell_embedder"):
-        cat_mask_batch = _pad_batch_to_multiple_of(cat_mask_batch, num_data_shards)
         cat_mask_batch = jax.device_put(
             jnp.array(cat_mask_batch, dtype=jnp.bool_), data_sharding
         )
@@ -1684,8 +1697,8 @@ class TabFMClassifier(ClassifierMixin, BaseEstimator):
             self.model, X_batch, y_batch, train_size, d_batch
         )
 
-      # Slice output to keep only test predictions and unpadded batch.
-      out = out[:orig_batch_size, train_size_val:, :]
+      # Slice output to keep only test predictions (ignoring the sequence pad) and unpadded batch.
+      out = out[:orig_batch_size, train_size_val:orig_seq_len, :]
       from jax.experimental import multihost_utils  # pylint: disable=g-import-not-at-top
       out = multihost_utils.process_allgather(out, tiled=True)
       outputs.append(out)

--- a/tabfm/src/classifier_and_regressor.py
+++ b/tabfm/src/classifier_and_regressor.py
@@ -2058,6 +2058,18 @@ class TabFMRegressor(RegressorMixin, BaseEstimator):
     cat_masks_iter = cat_masks_split if cat_masks is not None else [None] * len(Xs_split)
     for X_batch, y_batch, cat_mask_batch in zip(Xs_split, ys_split, cat_masks_iter):
       orig_batch_size = X_batch.shape[0]
+      orig_seq_len = X_batch.shape[1]
+
+      # Follow prefill(): pad sequence length T (n_row) to a multiple of 128
+      # with -100. Padded rows fall past train_size and are sliced off below.
+      _block_size = 128
+      _T_full = X_batch.shape[1]
+      _pad_len = ((_T_full - 1) // _block_size + 1) * _block_size - _T_full
+      if _pad_len > 0:
+        X_batch = np.pad(
+            X_batch, ((0, 0), (0, _pad_len), (0, 0)), constant_values=-100.0
+        )
+
       X_batch = _pad_batch_to_multiple_of(X_batch, num_data_shards)
       y_batch = _pad_batch_to_multiple_of(y_batch, num_data_shards)
 
@@ -2080,8 +2092,6 @@ class TabFMRegressor(RegressorMixin, BaseEstimator):
             constant_values=-100.0,
         )
 
-
-
       if cat_mask_batch is not None and hasattr(self.model, "cell_embedder"):
         cat_mask_batch = _pad_batch_to_multiple_of(cat_mask_batch, num_data_shards)
         cat_mask_batch = jax.device_put(
@@ -2095,7 +2105,7 @@ class TabFMRegressor(RegressorMixin, BaseEstimator):
             self.model, X_batch, y_batch, train_size, d_batch
         )
 
-      out = out[:orig_batch_size, train_size_val:, :]
+      out = out[:orig_batch_size, train_size_val:orig_seq_len, :]
       from jax.experimental import multihost_utils  # pylint: disable=g-import-not-at-top
       out = multihost_utils.process_allgather(out, tiled=True)
       outputs.append(out)

--- a/tabfm/src/tabfm_v1_0_0.py
+++ b/tabfm/src/tabfm_v1_0_0.py
@@ -105,10 +105,20 @@ class RegressionConfig(Config):
   loss: str = "rmse"
 
 
-# Process-wide cache of restored models, keyed by load settings. The restored
-# weights are immutable and shared safely across callers (e.g. AutoGluon /
-# TabArena bagging fits many child models in one process), so this avoids
-# re-running the ~19s Orbax checkpoint restore on every call.
+# Process-wide memo of restored models. Caching avoids re-running the ~19s
+# Orbax checkpoint restore on every call (e.g. AutoGluon / TabArena bagging
+# fits many child models in one process); the restored weights are immutable
+# and shared safely across callers.
+#
+# It is a dict keyed by load settings (model_type, checkpoint_path, step,
+# attention_impl, dtype) rather than a single slot for two reasons:
+#   1. Distinct variants can coexist in one process -- most commonly the
+#      classification and regression models -- so a single slot would evict
+#      one whenever the other is loaded and re-pay the restore each switch.
+#   2. Correctness: these settings change which weights/architecture you get,
+#      so the key guarantees we never return a model loaded with settings
+#      different from those requested. (Equivalent to functools.lru_cache on
+#      the arguments; kept explicit for the use_cache=False escape hatch.)
 _LOAD_CACHE: Dict[Any, "TabFM"] = {}
 
 

--- a/tabfm/src/tabfm_v1_0_0.py
+++ b/tabfm/src/tabfm_v1_0_0.py
@@ -105,10 +105,10 @@ class RegressionConfig(Config):
   loss: str = "rmse"
 
 
-# Process-wide memo of restored models. Caching avoids re-running the ~19s
-# Orbax checkpoint restore on every call (e.g. AutoGluon / TabArena bagging
-# fits many child models in one process); the restored weights are immutable
-# and shared safely across callers.
+# Process-wide memo of restored models. Caching avoids re-running the Orbax
+# checkpoint restore on every call (e.g. AutoGluon / TabArena bagging fits many
+# child models in one process); the restored weights are immutable and shared
+# safely across callers.
 #
 # It is a dict keyed by load settings (model_type, checkpoint_path, step,
 # attention_impl, dtype) rather than a single slot for two reasons:

--- a/tabfm/src/tabfm_v1_0_0.py
+++ b/tabfm/src/tabfm_v1_0_0.py
@@ -105,12 +105,21 @@ class RegressionConfig(Config):
   loss: str = "rmse"
 
 
+# Process-wide cache of restored models, keyed by load settings. The restored
+# weights are immutable and shared safely across callers (e.g. AutoGluon /
+# TabArena bagging fits many child models in one process), so this avoids
+# re-running the ~19s Orbax checkpoint restore on every call.
+_LOAD_CACHE: Dict[Any, "TabFM"] = {}
+
+
 def load(
     model_type: str = "classification",
     checkpoint_path: Optional[str] = None,
     step: Optional[int] = None,
+    attention_impl: str = 'flash',
     *,
     dtype: Any = jnp.bfloat16,
+    use_cache: bool = True,
 ) -> TabFM:
   """Loads the TabFM v1.0.0 model with pre-trained weights.
 
@@ -123,11 +132,21 @@ def load(
     checkpoint_path: Local directory containing the 'orbax/' checkpoint, or None
       to download from Hugging Face.
     step: The checkpoint step to restore (for local loading).
+    attention_impl: Attention implementation to use ('jax', 'flash', etc.).
     dtype: Calculations dtype for JAX.
+    use_cache: If True (default), reuse a process-wide cached model when one was
+      already loaded with identical settings. Set False to force a fresh load.
 
   Returns:
     An initialized TabFM model with restored weights.
   """
+  cache_key = (model_type, checkpoint_path, step, attention_impl, str(dtype))
+  if use_cache and cache_key in _LOAD_CACHE:
+    return _LOAD_CACHE[cache_key]
+
+  from tabfm.src.model import AttentionImplementation
+  att_impl = AttentionImplementation(attention_impl)
+  
   # 1. Instantiate model with hardcoded config based on model_type
   if model_type == "classification":
     config = ClassificationConfig()
@@ -140,7 +159,9 @@ def load(
     )
 
   rngs = nnx.Rngs(0)
-  model = TabFM(rngs=rngs, dtype=dtype, **config.to_dict())
+  config_dict = config.to_dict()
+  config_dict['icl_attention_impl'] = att_impl
+  model = TabFM(rngs=rngs, dtype=dtype, **config_dict)
 
   # 2. Get checkpoint directory
   if checkpoint_path is None:
@@ -184,4 +205,6 @@ def load(
   )
   nnx.update(model, restored["params"])
 
+  if use_cache:
+    _LOAD_CACHE[cache_key] = model
   return model


### PR DESCRIPTION
Two independent inference-performance changes:

1. **load(): checkpoint cache + `attention_impl` param** (`tabfm_v1_0_0.py`). A process-wide `_LOAD_CACHE` lets repeated loads (e.g. AutoGluon/TabArena bagging) skip the ~19s Orbax restore; an `attention_impl` param (default 'flash') is injected as `icl_attention_impl` so callers can pick the ICL attention kernel.
2. **128-row padding in `_batch_forward`** (`classifier_and_regressor.py`). Pad the sequence to a multiple of 128 with -100 before the jitted predict step (and slice it off the output), bucketing varying dataset sizes to the same compiled shape to avoid a recompile per length. Padded rows fall past `train_size` and are masked, so results are unchanged.