### PR TITLE
Add tamannarayan to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 # Default owners for everything in the repo.
 # These users are automatically requested for review on all pull requests.
-* @abhidas @siriuz42 @rajatsen91 @erzel @weihaokong
+* @abhidas @siriuz42 @rajatsen91 @erzel @weihaokong @tamannarayan


### PR DESCRIPTION
Adds @tamannarayan as a default code owner so they are auto-requested for review on all PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)