### PR TITLE
Support restructured HF JAX checkpoints layout

### DIFF
--- a/tabfm/src/tabfm_v1_0_0.py
+++ b/tabfm/src/tabfm_v1_0_0.py
@@ -30,7 +30,7 @@ from tabfm.src import checkpointing
 from tabfm.src.model import TabFM, YEmbeddingScheme
 
 # Hugging Face repository ID for TabFM v1.0.0
-HF_REPO_ID = "google/tabfm-v1-0-0"
+HF_REPO_ID = "google/tabfm-1.0.0-jax"
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
Since we'll be supporting pytorch checkpoints, we've moved the JAX checkpoint in HF into a jax/... subdirectory. This PR changes the code to look for it in the correct place.