### PR TITLE
Fix TabFMClassifier.predict() returning object-dtype labels

### DIFF
--- a/tabfm/src/classifier_and_regressor.py
+++ b/tabfm/src/classifier_and_regressor.py
@@ -2697,7 +2697,7 @@ class TabFMClassifier(ClassifierMixin, BaseEstimator):
     y = np.argmax(proba[:, : self.n_classes_], axis=1)
     y_2d = y.reshape(-1, 1)
     y_decoded = self.y_encoder_.inverse_transform(y_2d)
-    return y_decoded.flatten()
+    return y_decoded.flatten().astype(self.classes_.dtype)
 
   @jt.typed
   @staticmethod


### PR DESCRIPTION
CategoricalOrdinalEncoder.inverse_transform() returns an object-dtype ndarray (np.empty(..., dtype=object)). predict() flattens this and returns it directly, so predicted labels come back as plain Python ints/strs wrapped in an object array instead of a proper numeric/ string dtype.

sklearn's type_of_target() treats object-dtype arrays of Python scalars as 'unknown' rather than 'multiclass', even when the values themselves are valid class labels. This breaks any sklearn scoring function (accuracy_score, cross_val_score, etc.) called on predict() output, since y_true (typically int64) types as 'multiclass' while y_pred types as 'unknown':

  ValueError: Classification metrics can't handle a mix of
  multiclass and unknown targets

Cast the decoded output to self.classes_.dtype before returning to match the dtype of the original training labels.

Repro: cross_val_score(TabFMClassifier(...), X, y, cv=..., scoring='accuracy') raises the above even with a dummy model returning random logits — confirms this is dtype handling, not a data or model issue.