### PR TITLE
Enable activation chunking by default with fixed memory-safe sizes

### DIFF
--- a/tabfm/src/pytorch/model.py
+++ b/tabfm/src/pytorch/model.py
@@ -417,6 +417,18 @@ class ICLearning(nn.Module):
     return self.decoder(self.ln(out))
 
 
+# Always-on activation-chunk sizes. TabFM runs the whole training fold as one
+# in-context sequence, so a single forward materialises activations that grow
+# with rows * features and OOM the GPU on large tasks. These sizes split each
+# stage's largest activation along an independent axis, bounding peak memory.
+# Chunking is exact (identical outputs) and a no-op when an input is smaller
+# than the chunk size, and it costs <1% runtime otherwise, so it is always on.
+# Sizes are chosen for memory safety on a 40 GB GPU across TabArena-scale tasks.
+_ROW_CHUNK_SIZE = 4096   # rows per chunk (Fourier cell embedding + row interaction)
+_COL_CHUNK_SIZE = 16     # feature-instances per chunk (column set-transformer)
+_FFN_CHUNK_SIZE = 8192   # tokens per chunk (feed-forward expansion in every block)
+
+
 class TabFM(nn.Module):
   def __init__(self, *, embed_dim=8, max_classes=3, col_num_blocks=2,
                col_nhead=2, col_num_inds=4, row_num_blocks=2, row_nhead=2,
@@ -440,6 +452,16 @@ class TabFM(nn.Module):
     self.icl_predictor = ICLearning(icl_dim, icl_num_blocks, icl_nhead, max_classes,
                                     icl_dim * ff_factor,
                                     decoder_hidden or icl_dim * 2, is_classifier)
+
+    # Enable activation chunking by default (see the module constants above).
+    # The per-block knobs stay settable (e.g. to None) for benchmarking.
+    for module in self.modules():
+      if hasattr(module, "row_chunk_size"):
+        module.row_chunk_size = _ROW_CHUNK_SIZE
+      if hasattr(module, "col_chunk_size"):
+        module.col_chunk_size = _COL_CHUNK_SIZE
+      if hasattr(module, "ffn_chunk_size"):
+        module.ffn_chunk_size = _FFN_CHUNK_SIZE
 
   def forward(self, x, y, train_size, cat_mask=None, d=None):
     emb = self.cell_embedder(x, y, train_size, cat_mask, d=d)


### PR DESCRIPTION
## Problem
The PyTorch model exposes per-block `row_chunk_size` / `col_chunk_size` / `ffn_chunk_size` knobs that bound peak activation memory, but they default to `None` (off). TabFM runs the whole training fold as one in-context sequence, so a single forward materializes activations that grow with `rows * features` and OOM the GPU on large tasks (and unchunked, large row counts hit CUDA grid-config limits, not just OOM). Today only the AutoGluon wrapper enables chunking; the library itself OOMs on large inputs out of the box.

## Change
Enable chunking by default in `TabFM.__init__` with fixed, memory-safe sizes:
```
row=4096, col=16, ffn=8192
```
Chunking is exact (bit-identical outputs) and a no-op when an input is smaller than the chunk size, so it is safe to always enable. The per-block knobs remain settable (e.g. to `None`) for benchmarking. Applies to both classifier and regressor (same `TabFM` module).

## Why these sizes (measured on APSFailure, 76k×170, A100-40GB)
| ffn | col | row | time | peak |
|--:|--:|--:|--:|--:|
| 8192 | 16 | 4096 (**default**) | 49.5s | **29.8 GB** |
| 16384 | 32 | 8192 | 49.3s | 29.8 GB |
| 32768 | 64 | 8192 | 51.1s | 40.2 GB |
| 262144 | 64 | 4096 | 50.5s | 40.2 GB |
| 4096 | 8 | 2048 (too small) | 54.3s | 29.8 GB |

Time is flat across sizes (larger chunks give no speedup), while larger `col` costs +10 GB and OOMs on wider inputs. The chosen sizes are in the fast tier with the lowest memory — safe on a 40 GB GPU across TabArena-scale tasks.

## Notes
- No numerical change (chunking is exact; verified defaults are set and the small-shape paths are no-ops).
- The pre-existing `test_jax_pytorch_parity` failure (bf16 diff ~5e-3 vs a 1e-4 threshold) is unrelated to this change (fails identically on `main`).