### PR TITLE
Avoid eager full-train re-transform in EnsembleGenerator._transform_features

### DIFF
--- a/tabfm/src/classifier_and_regressor.py
+++ b/tabfm/src/classifier_and_regressor.py
@@ -1606,15 +1606,9 @@ class EnsembleGenerator(TransformerMixin, BaseEstimator):
           _apply_categorical_permutation(X_full, cat_perm)
           X_variant_instance = preprocessor.transform(X_full)
         else:
-          X_train_trans = getattr(
-              preprocessor, "X_transformed_", preprocessor.transform(self.X_)
-          )[train_idx]
+          X_train_trans = preprocessor.X_transformed_[train_idx]
           X_test_trans = (
-              getattr(
-                  preprocessor,
-                  "X_transformed_",
-                  preprocessor.transform(self.X_),
-              )[val_idx]
+              preprocessor.X_transformed_[val_idx]
               if val_idx is not None
               else preprocessor.transform(X_test)
           )


### PR DESCRIPTION
`EnsembleGenerator._transform_features` used `getattr(preprocessor, "X_transformed_", preprocessor.transform(self.X_))` as a lazy-cache pattern, but `getattr` evaluates its default argument eagerly, so the full training set was re-transformed on every call, per ensemble member — even though `PreprocessingPipeline.fit()` always sets `X_transformed_` (both the zero-features early return and the normal path), making the fallback dead code.

This made prediction cost scale with context size rather than query size: a small-batch `predict_proba` against a ~50K-row context paid one full context re-transform per ensemble member, and two per member during cross-validation folds (the second `getattr` default is also evaluated when `val_idx` is set). Chunked prediction over a large context was effectively unusable as a result.

Fix: reference the cached `X_transformed_` directly. Behavior is unchanged by construction — the `getattr` always found the attribute and discarded the eagerly computed default — and predictions verified identical before/after the change.