### PR TITLE
Fix silent query-axis mask/bias collapse in memory-efficient (FLASH) attention

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -40,6 +40,7 @@ if not _has_jax:
   collect_ignore += [
       "tabfm/src/jax/model_test.py",
       "tabfm/src/jax/checkpointing_test.py",
+      "tabfm/src/jax/memory_efficient_attention_test.py",
   ]
 # pytorch/model_test.py is a torch<->jax parity test: it imports both flax and
 # torch, so it needs *both* backends installed.

--- a/tabfm/src/jax/BUILD
+++ b/tabfm/src/jax/BUILD
@@ -55,6 +55,17 @@ py_test(
 )
 
 py_test(
+    name = "memory_efficient_attention_test",
+    srcs = ["memory_efficient_attention_test.py"],
+    deps = [
+        ":memory_efficient_attention",
+        "@pip//absl_py",
+        "@pip//jax",
+        "@pip//numpy",
+    ],
+)
+
+py_test(
     name = "checkpointing_test",
     srcs = ["checkpointing_test.py"],
     deps = [

--- a/tabfm/src/jax/memory_efficient_attention.py
+++ b/tabfm/src/jax/memory_efficient_attention.py
@@ -417,10 +417,8 @@ def dot_product_attention_queries_per_head(
     if bias is not None:
       # If bias is not broadcasted yet, dynamic slice would fail with full slice
       # size. In this case we keep the bias unbroadcasted.
-      # slice_q_len = min(bias.shape[-2], query_chunk_size)
-      # slice_k_len = min(bias.shape[-1], key_chunk_size)
-      slice_q_len = 1
-      slice_k_len = key_chunk_size
+      slice_q_len = min(bias.shape[-2], query_chunk_size)
+      slice_k_len = min(bias.shape[-1], key_chunk_size)
 
       local_bias = lax.dynamic_slice(
           bias,

--- a/tabfm/src/jax/memory_efficient_attention_test.py
+++ b/tabfm/src/jax/memory_efficient_attention_test.py
@@ -1,0 +1,123 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Regression tests for query-varying mask/bias handling in FLASH attention."""
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+from tabfm.src.jax import memory_efficient_attention
+
+from absl.testing import absltest
+
+_BATCH = 2
+_HEADS = 2
+_DIM = 8
+
+
+def _reference_attention(query, key, value, bias):
+  """Exact attention: the model's JAX backend."""
+  return jax.nn.dot_product_attention(
+      query=query, key=key, value=value, bias=bias, scale=1.0
+  )
+
+
+def _flash_attention(query, key, value, bias, chunk_size):
+  """FLASH attention, called the way MultiheadAttention calls it."""
+  return memory_efficient_attention.dot_product_attention_multihead(
+      query=query,
+      key=key,
+      value=value,
+      bias=bias,
+      dtype=query.dtype,
+      query_chunk_size=chunk_size,
+      key_chunk_size=chunk_size,
+  )
+
+
+def _mask_to_bias(mask):
+  """Keep-mask to additive bias, as MultiheadAttention builds it."""
+  return jnp.where(mask, 0.0, -1e30)
+
+
+class MemoryEfficientAttentionTest(absltest.TestCase):
+
+  def _random_qkv(self, q_len, kv_len):
+    rng = np.random.default_rng(0)
+    query = jnp.asarray(
+        rng.standard_normal((_BATCH, q_len, _HEADS, _DIM)), jnp.float32
+    )
+    key = jnp.asarray(
+        rng.standard_normal((_BATCH, kv_len, _HEADS, _DIM)), jnp.float32
+    )
+    value = jnp.asarray(
+        rng.standard_normal((_BATCH, kv_len, _HEADS, _DIM)), jnp.float32
+    )
+    return query, key, value
+
+  def _assert_flash_matches_reference(self, q_len, kv_len, bias, chunk_size):
+    query, key, value = self._random_qkv(q_len, kv_len)
+    actual = _flash_attention(query, key, value, bias, chunk_size)
+    expected = _reference_attention(query, key, value, bias)
+    np.testing.assert_allclose(
+        np.asarray(actual), np.asarray(expected), rtol=0, atol=1e-5
+    )
+
+  def test_query_varying_mask_multiple_chunks(self):
+    # A mask that varies per query row must not collapse to the chunk's first row.
+    q_len = kv_len = 256
+    query_idx = jnp.arange(q_len)[:, None]
+    key_idx = jnp.arange(kv_len)[None, :]
+    mask = jnp.broadcast_to(
+        (key_idx <= query_idx + 50)[None, None], (_BATCH, 1, q_len, kv_len)
+    )
+    self._assert_flash_matches_reference(
+        q_len, kv_len, _mask_to_bias(mask), chunk_size=128
+    )
+
+  def test_query_varying_mask_single_chunk(self):
+    # Same guarantee when the whole sequence is a single chunk (chunk_size == q_len).
+    q_len = kv_len = 64
+    query_idx = jnp.arange(q_len)[:, None]
+    key_idx = jnp.arange(kv_len)[None, :]
+    mask = jnp.broadcast_to(
+        (key_idx <= query_idx)[None, None], (_BATCH, 1, q_len, kv_len)
+    )
+    self._assert_flash_matches_reference(
+        q_len, kv_len, _mask_to_bias(mask), chunk_size=q_len
+    )
+
+  def test_broadcast_key_mask(self):
+    # The [B, 1, 1, S] key-padding mask the shipped model builds must stay exact.
+    q_len = kv_len = 256
+    key_idx = jnp.arange(kv_len)[None, :]
+    mask = jnp.broadcast_to(
+        (key_idx < 100)[None, None], (_BATCH, 1, 1, kv_len)
+    )
+    self._assert_flash_matches_reference(
+        q_len, kv_len, _mask_to_bias(mask), chunk_size=128
+    )
+
+  def test_kv_broadcastable_bias(self):
+    # A bias with kv dim 1 (broadcast over keys) must not crash dynamic_slice.
+    q_len = kv_len = 256
+    rng = np.random.default_rng(1)
+    bias = jnp.asarray(
+        rng.standard_normal((_BATCH, 1, q_len, 1)), jnp.float32
+    )
+    self._assert_flash_matches_reference(q_len, kv_len, bias, chunk_size=128)
+
+
+if __name__ == "__main__":
+  absltest.main()


### PR DESCRIPTION
## Summary

`bias_fn` in `dot_product_attention_queries_per_head` (`tabfm/src/jax/memory_efficient_attention.py`) hardcoded `slice_q_len = 1`, with the correct `min()` slicing commented out one line above, so any bias/mask that varies along the query axis is collapsed to each chunk's first row.

## Why it matters

Query-varying masks are supported: the docstring bias shape carries a full `q_length`, the shape-check accepts it, and `MultiheadAttention`'s 4-D `[B, #N, #T, T_src]` contract pins only `#N` to 1. 

FLASH is the default backend for the column and ICL layers (`tabfm_v1_0_0.py`), and on such a mask it silently returns each chunk's first row while the JAX backend of the same layer is correct. A kv-broadcastable bias (last dim 1) also crashes `lax.dynamic_slice`.

## Reproduction

Query-varying mask `[B, 1, T, S]` (query `t` attends keys `<= t + 50`), `T = S = 256`, chunk 128. "first-row collapsed" is the same mask with each chunk forced to its first row, which is what the bug produces.

<details>
<summary>Full repro script</summary>

```python
import jax
import jax.numpy as jnp
import numpy as np
from tabfm.src.jax import memory_efficient_attention as mea

B, H, D, T, S, CHUNK = 2, 2, 8, 256, 256, 128
rng = np.random.default_rng(0)
q = jnp.asarray(rng.standard_normal((B, T, H, D)), jnp.float32)
k = jnp.asarray(rng.standard_normal((B, S, H, D)), jnp.float32)
v = jnp.asarray(rng.standard_normal((B, S, H, D)), jnp.float32)

qi = jnp.arange(T)[:, None]
ki = jnp.arange(S)[None, :]
# query-varying mask [B, 1, T, S]: query t attends keys <= t + 50
bias = jnp.where(
    jnp.broadcast_to((ki <= qi + 50)[None, None], (B, 1, T, S)), 0.0, -1e30)
# the same mask with each chunk collapsed to its first query row (the bug's effect)
row0 = (jnp.arange(T) // CHUNK) * CHUNK
collapsed = jnp.where(
    jnp.broadcast_to((ki <= row0[:, None] + 50)[None, None], (B, 1, T, S)),
    0.0, -1e30)

def exact(b):
  return jax.nn.dot_product_attention(query=q, key=k, value=v, bias=b, scale=1.0)

flash = jnp.asarray(mea.dot_product_attention_multihead(
    query=q, key=k, value=v, bias=bias, dtype=q.dtype,
    query_chunk_size=CHUNK, key_chunk_size=CHUNK))
ref, col = exact(bias), exact(collapsed)
amax = lambda x: float(jnp.max(jnp.abs(x)))

print(f"query-varying mask, B={B} H={H} T={T} S={S} chunk={CHUNK}")
print(f"  exact-output scale (max|JAX|)          = {amax(ref):.2f}")
print(f"  max|FLASH - exact(JAX)|                = {amax(flash - ref):.3f}")
print(f"  max|FLASH - exact(first-row collapsed)|= {amax(flash - col):.2e}")
```

</details>

**Before**

```
query-varying mask, B=2 H=2 T=256 S=256 chunk=128
  exact-output scale (max|JAX|)          = 2.61
  max|FLASH - exact(JAX)|                = 3.832
  max|FLASH - exact(first-row collapsed)|= 1.67e-06
```
**After**
```
query-varying mask, B=2 H=2 T=256 S=256 chunk=128
  exact-output scale (max|JAX|)          = 2.61
  max|FLASH - exact(JAX)|                = 0.000
  max|FLASH - exact(first-row collapsed)|= 3.83e+00
```

## No behavior change for the shipped model

The `[B, 1, 1, S]` key-padding mask the model builds today is constant along the query axis, so its output is bit-identical before and after.
