### PR TITLE
README: load the regression checkpoint in the Regression Example

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,11 +106,11 @@ from tabfm import TabFMRegressor
 
 # OPTION A: JAX Backend
 from tabfm import tabfm_v1_0_0_jax as tabfm_v1_0_0
-model = tabfm_v1_0_0.load()
+model = tabfm_v1_0_0.load(model_type="regression")
 
 # OPTION B: PyTorch Backend
 # from tabfm import tabfm_v1_0_0_pytorch as tabfm_v1_0_0
-# model = tabfm_v1_0_0.load()
+# model = tabfm_v1_0_0.load(model_type="regression")
 
 # Initialize scikit-learn compatible regressor (works with either backend model)
 reg = TabFMRegressor(model=model)


### PR DESCRIPTION
The README's Regression Example calls bare `load()` for both backends, but both default to `model_type="classification"`.

Quickstart downloads the classification checkpoint and the first `predict()` crashes with `ValueError: cannot select an axis to squeeze out which has size not equal to one` (issue #32). 

This adds `model_type="regression"` to both calls, matching the bundled `examples/regression_example.py`.
