### PR TITLE
Fix predict crashing on multi-device hosts (IndivisibleError / device mismatch)

### DIFF
--- a/tabfm/src/BUILD
+++ b/tabfm/src/BUILD
@@ -31,6 +31,19 @@ py_test(
     ],
 )
 
+py_test(
+    name = "classifier_and_regressor_multidevice_test",
+    srcs = ["classifier_and_regressor_multidevice_test.py"],
+    deps = [
+        ":classifier_and_regressor",
+        "//tabfm/src/jax:model",
+        "@pip//absl_py",
+        "@pip//flax",
+        "@pip//jax",
+        "@pip//numpy",
+    ],
+)
+
 py_library(
     name = "torch_convert",
     srcs = ["hugging_face/torch_convert.py"],

--- a/tabfm/src/classifier_and_regressor.py
+++ b/tabfm/src/classifier_and_regressor.py
@@ -2260,10 +2260,6 @@ class TabFMClassifier(ClassifierMixin, BaseEstimator):
       )
 
       if not hasattr(self, _has_compiled_attr):
-        data_sharding = NamedSharding(
-            jax.sharding.Mesh(jax.devices(), ("data",)), PartitionSpec("data")
-        )
-
         if cat_masks is not None and hasattr(self.model, "cell_embedder"):
 
           @nnx.jit(
@@ -3039,10 +3035,6 @@ class TabFMRegressor(RegressorMixin, BaseEstimator):
       )
 
       if not hasattr(self, _has_compiled_attr):
-        data_sharding = NamedSharding(
-            jax.sharding.Mesh(jax.devices(), ("data",)), PartitionSpec("data")
-        )
-
         if cat_masks is not None and hasattr(self.model, "cell_embedder"):
 
           @nnx.jit(

--- a/tabfm/src/classifier_and_regressor_multidevice_test.py
+++ b/tabfm/src/classifier_and_regressor_multidevice_test.py
@@ -1,0 +1,102 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Regression tests for predict on a host with more than one visible device.
+
+These run on simulated CPU devices, so they exercise the multi-device forward
+path in CI without needing GPUs. The device count must be requested before JAX
+initializes, which is why this lives in its own module.
+"""
+
+import os
+
+# Request two host devices before JAX initializes so jax.devices() returns more
+# than one. Kept in its own test module so it does not affect other tests.
+os.environ.setdefault("XLA_FLAGS", "--xla_force_host_platform_device_count=2")
+
+from absl.testing import absltest
+import numpy as np
+
+try:
+  from flax import nnx
+  from tabfm.src.jax import model as tabfm_model
+
+  HAS_JAX = True
+except ImportError:
+  HAS_JAX = False
+
+from tabfm.src.classifier_and_regressor import TabFMClassifier
+from tabfm.src.classifier_and_regressor import TabFMRegressor
+
+# pylint: disable=invalid-name
+
+
+def _tiny_model(loss):
+  return tabfm_model.TabFM(
+      loss=loss,
+      max_classes=2,
+      embed_dim=8,
+      col_num_blocks=1,
+      col_nhead=2,
+      col_num_inds=8,
+      row_num_blocks=1,
+      row_nhead=2,
+      row_num_cls=1,
+      icl_num_blocks=1,
+      icl_nhead=2,
+      rngs=nnx.Rngs(0),
+  )
+
+
+class MultiDevicePredictTest(absltest.TestCase):
+  """predict must work when more than one device is visible and no mesh is set.
+
+  Without a user-configured mesh the default batch is 1, but the JAX forward
+  path built a data sharding over every visible device. That forced a batch of
+  size 1 into an N-way shard (IndivisibleError) and placed the inputs on all
+  devices while the weights stayed on device 0 (device mismatch). The forward
+  path now keeps the sharding it derives from the active mesh (none by default,
+  so the call is replicated), which is correct for one or many devices.
+  """
+
+  def setUp(self):
+    super().setUp()
+    if not HAS_JAX:
+      self.skipTest("JAX is required for this test.")
+    import jax  # pylint: disable=g-import-not-at-top
+
+    if len(jax.devices()) < 2:
+      self.skipTest("Requires at least two (simulated) devices.")
+
+  def test_classifier_predict_multi_device(self):
+    clf = TabFMClassifier(model=_tiny_model("cross_entropy"), n_estimators=2)
+    rng = np.random.RandomState(0)
+    X = rng.rand(20, 3)
+    y = rng.randint(0, 2, size=20)
+    clf.fit(X, y)
+    preds = clf.predict(X[:5])
+    self.assertEqual(np.asarray(preds).shape, (5,))
+
+  def test_regressor_predict_multi_device(self):
+    reg = TabFMRegressor(model=_tiny_model("mse"), n_estimators=2)
+    rng = np.random.RandomState(0)
+    X = rng.rand(20, 3)
+    y = rng.rand(20)
+    reg.fit(X, y)
+    preds = reg.predict(X[:5])
+    self.assertEqual(np.asarray(preds).shape, (5,))
+
+
+if __name__ == "__main__":
+  absltest.main()


### PR DESCRIPTION
## Problem

On a host with two or more visible devices, the first `predict` / `predict_proba` call crashes with default settings.

`TabFMClassifier` / `TabFMRegressor` default to `batch_size=1` with no user mesh. The JAX forward path derives `data_sharding` from the active mesh (`None` when no mesh is set), but then on first compile it unconditionally rebuilds it over every device from `jax.devices()`:

```python
if not hasattr(self, _has_compiled_attr):
    data_sharding = NamedSharding(
        jax.sharding.Mesh(jax.devices(), ("data",)), PartitionSpec("data")
    )
```

This discards the sharding derived just above and produces two failures:

- With `batch_size=1` (the default), a batch of size 1 is forced into an N-way shard: `IndivisibleError: array axis 0 is partitioned 2 times, but the dimension size is 1`.
- With a divisible batch (e.g. `batch_size=32`), inputs are sharded over all devices while the model weights stay on device 0, raising an incompatible-devices error.

So `predict` does not work through the public API on a multi-GPU host unless a single device is pinned (`CUDA_VISIBLE_DEVICES=0`).

## Fix

Remove the override so the forward path uses the sharding it already derives: `None` (replicated) when no mesh is set, or the mesh sharding otherwise. `predict` now works on one or many visible devices, and explicit multi-device sharding still works through a user-configured mesh. Applies to both the classifier and regressor paths.

## Reproduce (simulated on two CPU devices, no GPU needed)

```python
import os
os.environ["XLA_FLAGS"] = "--xla_force_host_platform_device_count=2"
import numpy as np
from flax import nnx
from tabfm.src.jax import model as tabfm_model
from tabfm.src.classifier_and_regressor import TabFMClassifier

m = tabfm_model.TabFM(loss="cross_entropy", max_classes=2, embed_dim=8,
    col_num_blocks=1, col_nhead=2, col_num_inds=8, row_num_blocks=1,
    row_nhead=2, row_num_cls=1, icl_num_blocks=1, icl_nhead=2, rngs=nnx.Rngs(0))
clf = TabFMClassifier(model=m, n_estimators=2)
X = np.random.rand(20, 3); y = np.random.randint(0, 2, 20)
clf.fit(X, y)
clf.predict(X[:5])   # IndivisibleError before this change; works after
```

## Test

Adds `classifier_and_regressor_multidevice_test.py`, which runs the classifier and regressor default-batch `predict` path on simulated CPU devices, covering the multi-device path in CI without GPUs. It fails on the current code and passes with this change. All existing `classifier_and_regressor_test.py` tests continue to pass.
