### PR TITLE
Fail fast with a clear error when the checkpoint type does not match the estimator

### DIFF
--- a/tabfm/src/classifier_and_regressor.py
+++ b/tabfm/src/classifier_and_regressor.py
@@ -1816,6 +1816,49 @@ def _predict_step_pytorch(
   return out_t.float().cpu().numpy()  # upcast: numpy has no bfloat16
 
 
+def _check_classifier_output_dim(output_dim: int, n_classes: int) -> None:
+  """Validates that the model produces logits for all target classes.
+
+  Args:
+    output_dim: Size of the model output's last axis.
+    n_classes: Number of classes seen during fit.
+
+  Raises:
+    ValueError: If the model outputs fewer values per row than there are
+      classes, which usually means a regression checkpoint is being used for
+      classification.
+  """
+  if output_dim < n_classes:
+    raise ValueError(
+        f"The model returned {output_dim} value(s) per row, but this"
+        f" TabFMClassifier was fit on {n_classes} classes. This usually means"
+        " a regression checkpoint is being used for classification. Load the"
+        " classification weights instead, e.g."
+        " `tabfm_v1_0_0.load(model_type='classification')`."
+    )
+
+
+def _check_regressor_output_dim(output_dim: int) -> None:
+  """Validates that the model produces scalar regression outputs.
+
+  Args:
+    output_dim: Size of the model output's last axis.
+
+  Raises:
+    ValueError: If the model outputs more than one value per row, which
+      usually means a classification checkpoint is being used for regression.
+  """
+  if output_dim != 1:
+    raise ValueError(
+        f"The model returned {output_dim} values per row, but TabFMRegressor"
+        " expects a single regression output. This usually means a"
+        " classification checkpoint is being used for regression; note that"
+        " `tabfm_v1_0_0.load()` defaults to the classification weights. Load"
+        " the regression weights instead with"
+        " `tabfm_v1_0_0.load(model_type='regression')`."
+    )
+
+
 # ---------------------------------------------------------------------------
 # Classifier
 # ---------------------------------------------------------------------------
@@ -2459,6 +2502,7 @@ class TabFMClassifier(ClassifierMixin, BaseEstimator):
       out = self._batch_forward(
           Xs_batch, ys_batch, cat_masks_batch, ds=ds_batch
       )
+      _check_classifier_output_dim(out.shape[-1], n_classes)
       out = out[..., :n_classes]
 
       for i, (_, shift_offset, _, _) in enumerate(configs_flat):
@@ -2606,6 +2650,7 @@ class TabFMClassifier(ClassifierMixin, BaseEstimator):
     ) = self.ensemble_generator_.prepare_ensemble_tensors(data)
 
     outputs = self._batch_forward(Xs_all, ys_all, cat_masks_all, ds=ds_all)
+    _check_classifier_output_dim(outputs.shape[-1], self.n_classes_)
     outputs = outputs[..., :self.n_classes_]
 
     # Extract class shift offsets from ensemble generator
@@ -3245,6 +3290,7 @@ class TabFMRegressor(RegressorMixin, BaseEstimator):
       out = self._batch_forward(
           Xs_batch, ys_batch, cat_masks_batch, ds=ds_batch
       )
+      _check_regressor_output_dim(out.shape[-1])
 
       preds = out.squeeze(-1)
 
@@ -3270,6 +3316,7 @@ class TabFMRegressor(RegressorMixin, BaseEstimator):
     ) = self.ensemble_generator_.prepare_ensemble_tensors(data)
 
     output = self._batch_forward(Xs_all, ys_all, cat_masks_all, ds=ds_all)
+    _check_regressor_output_dim(output.shape[-1])
     predictions = output.squeeze(-1)
     return predictions
 

--- a/tabfm/src/classifier_and_regressor_test.py
+++ b/tabfm/src/classifier_and_regressor_test.py
@@ -645,6 +645,63 @@ class BatchForwardTest(absltest.TestCase):
 
 
 @unittest.skipUnless(HAS_JAX, "JAX is required")
+class ModelTypeMismatchTest(absltest.TestCase):
+  """Using the wrong checkpoint type fails fast with an actionable error."""
+
+  def _tiny_model(self, loss):
+    return tabfm_model.TabFM(
+        loss=loss,
+        max_classes=10,
+        embed_dim=8,
+        col_num_blocks=1,
+        col_nhead=2,
+        col_num_inds=8,
+        row_num_blocks=1,
+        row_nhead=2,
+        row_num_cls=1,
+        icl_num_blocks=1,
+        icl_nhead=2,
+        rngs=nnx.Rngs(0),
+    )
+
+  def test_regressor_predict_raises_on_classification_model(self):
+    regressor = TabFMRegressor(
+        model=self._tiny_model("cross_entropy"), n_estimators=2
+    )
+    X = np.random.rand(10, 3)
+    regressor.fit(X, np.random.rand(10))
+
+    with self.assertRaisesRegex(ValueError, "model_type='regression'"):
+      regressor.predict(np.random.rand(4, 3))
+
+  def test_regressor_predict_oof_raises_on_classification_model(self):
+    regressor = TabFMRegressor(
+        model=self._tiny_model("cross_entropy"), n_estimators=2
+    )
+    X = np.random.rand(10, 3)
+    regressor.fit(X, np.random.rand(10))
+
+    with self.assertRaisesRegex(ValueError, "model_type='regression'"):
+      regressor.predict_oof(cv=2)
+
+  def test_classifier_predict_proba_raises_on_regression_model(self):
+    classifier = TabFMClassifier(model=self._tiny_model("rmse"), n_estimators=2)
+    X = np.random.rand(10, 3)
+    classifier.fit(X, np.array([0, 1] * 5))
+
+    with self.assertRaisesRegex(ValueError, "fit on 2 classes"):
+      classifier.predict_proba(np.random.rand(4, 3))
+
+  def test_classifier_predict_oof_proba_raises_on_regression_model(self):
+    classifier = TabFMClassifier(model=self._tiny_model("rmse"), n_estimators=2)
+    X = np.random.rand(10, 3)
+    classifier.fit(X, np.array([0, 1] * 5))
+
+    with self.assertRaisesRegex(ValueError, "fit on 2 classes"):
+      classifier.predict_oof_proba(cv=2)
+
+
+@unittest.skipUnless(HAS_JAX, "JAX is required")
 class CalibrationTest(absltest.TestCase):
 
   def setUp(self):


### PR DESCRIPTION
## Summary

Passing a checkpoint of the wrong model type to the sklearn estimators currently fails in two opposite ways:

- **Classification checkpoint → `TabFMRegressor`** (what the Regression Example in the README did until #41): the model returns `max_classes = 10` values per row, and `predict()` crashes deep in `_predict_internal` with numpy's cryptic `ValueError: cannot select an axis to squeeze out which has size not equal to one`. This is the failure reported in #43, and it reproduces at any row count, not just 4000+.
- **Regression checkpoint → `TabFMClassifier`**: worse, no error at all. `predict_proba()` slices the single regression output to `[..., :n_classes]`, softmaxes a width-1 axis, and silently returns all-1.0 "probabilities" of shape `(T, 1)`, so `predict()` always returns the first class.

This PR validates the model output width at the four estimator-level call sites that consume `_batch_forward` outputs (`_predict_internal` / `predict_oof` on the regressor, `_predict_proba_internal` / `predict_oof_proba` on the classifier) and raises a `ValueError` that names the likely cause and the exact fix, e.g.:

> The model returned 10 values per row, but TabFMRegressor expects a single regression output. This usually means a classification checkpoint is being used for regression; note that `tabfm_v1_0_0.load()` defaults to the classification weights. Load the regression weights instead with `tabfm_v1_0_0.load(model_type='regression')`.

## Why the checks live in the callers, not `_batch_forward`

`_batch_forward` is deliberately loss-agnostic. `test_regressor_batch_forward_cross_entropy` pins its pass-through behavior (a cross-entropy model yields `(B, T_test, 10)` through the regressor's `_batch_forward`). The checks therefore sit where the wrong width actually corrupts results, and `_batch_forward` behavior is unchanged.

## Reproduction

<details>
<summary>Tiny-random-model script (CPU, no pretrained weights needed)</summary>

```python
import numpy as np
from flax import nnx
from tabfm.src.jax import model as tabfm_model
from tabfm.src.classifier_and_regressor import TabFMClassifier, TabFMRegressor

TINY = dict(max_classes=10, embed_dim=8, col_num_blocks=1, col_nhead=2,
            col_num_inds=8, row_num_blocks=1, row_nhead=2, row_num_cls=1,
            icl_num_blocks=1, icl_nhead=2)

rng = np.random.default_rng(0)
X, y = rng.random((50, 3)), rng.random(50)

# 1) classification model in TabFMRegressor (issue #43, n=50 suffices)
reg = TabFMRegressor(
    model=tabfm_model.TabFM(loss="cross_entropy", rngs=nnx.Rngs(0), **TINY),
    n_estimators=2)
reg.fit(X, y)
reg.predict(rng.random((5, 3)))
# before: ValueError: cannot select an axis to squeeze out which has size not equal to one
# after:  ValueError: The model returned 10 values per row, but TabFMRegressor expects ...

# 2) regression model in TabFMClassifier
clf = TabFMClassifier(
    model=tabfm_model.TabFM(loss="rmse", rngs=nnx.Rngs(0), **TINY),
    n_estimators=2)
clf.fit(X, rng.integers(0, 3, 50))
clf.predict_proba(rng.random((5, 3)))
# before: silently returns shape (5, 1), all values 1.0
# after:  ValueError: The model returned 1 value(s) per row, but this TabFMClassifier was fit on 3 classes ...
```

</details>

## Testing

- 4 new tests (`ModelTypeMismatchTest`) cover regressor × {`predict`, `predict_oof`} and classifier × {`predict_proba`, `predict_oof_proba`} with tiny random models through the real (non-mocked) forward path.
- `pytest tabfm/src/classifier_and_regressor_test.py tabfm/src/classifier_and_regressor_pytorch_test.py` → 42 passed.
- No behavior change for correctly paired checkpoints: the checks only read the output shape. The checks are backend-agnostic (both the JAX and PyTorch paths funnel through the same call sites).

Addresses #43.
