### PR TITLE
Fix sklearn-layer crashes on duplicate and non-string column names

### DIFF
--- a/tabfm/src/classifier_and_regressor.py
+++ b/tabfm/src/classifier_and_regressor.py
@@ -297,8 +297,8 @@ class DatetimeTransformer(BaseEstimator, TransformerMixin):
   dayofweek) in addition to its Unix-nanosecond integer representation.
   """
 
-  features_in: List[str]
-  _fillna_map: Dict[str, Any]
+  features_in: List[int]
+  _fillna_map: Dict[int, Any]
 
   def __init__(self, features: Optional[List[str]] = None):
     """Initialises the transformer.
@@ -326,12 +326,14 @@ class DatetimeTransformer(BaseEstimator, TransformerMixin):
     """
     if not isinstance(X, pd.DataFrame):
       X = pd.DataFrame(X)
-    self.features_in = list(X.columns)
-    for feature in self.features_in:
+    # Track columns by position: non-string column names would break the
+    # synthetic "<column>.<part>" labels built in transform().
+    self.features_in = list(range(X.shape[1]))
+    for pos in self.features_in:
       series = pd.to_datetime(
-          X[feature], utc=True, errors="coerce", format="mixed"
+          X.iloc[:, pos], utc=True, errors="coerce", format="mixed"
       )
-      self._fillna_map[feature] = series.mean()
+      self._fillna_map[pos] = series.mean()
     return self
 
   def transform(self, X: Any) -> np.ndarray:
@@ -346,18 +348,18 @@ class DatetimeTransformer(BaseEstimator, TransformerMixin):
     if not isinstance(X, pd.DataFrame):
       X = pd.DataFrame(X)
     X_datetime = pd.DataFrame(index=X.index)
-    for feature in self.features_in:
+    for pos in self.features_in:
       series = pd.to_datetime(
-          X[feature].copy(), utc=True, errors="coerce", format="mixed"
+          X.iloc[:, pos].copy(), utc=True, errors="coerce", format="mixed"
       )
       broken_idx = series[
           (series == "NaT") | series.isna() | series.isnull()
       ].index
       if len(broken_idx) > 0:
-        series.loc[broken_idx] = self._fillna_map[feature]
-      X_datetime[feature] = pd.to_numeric(series)
+        series.loc[broken_idx] = self._fillna_map[pos]
+      X_datetime[f"{pos}"] = pd.to_numeric(series)
       for dt_feature in self.features:
-        X_datetime[feature + "." + dt_feature] = getattr(
+        X_datetime[f"{pos}.{dt_feature}"] = getattr(
             series.dt, dt_feature
         ).astype(np.int64)
     return X_datetime.values
@@ -414,25 +416,33 @@ class TransformToNumerical(TransformerMixin, BaseEstimator):
       self.tfm_ = FunctionTransformer()
       return self
 
-    datetime_cols = []
-    cat_cols = []
-    numeric_cols = []
+    if X.columns.duplicated().any():
+      # sklearn's ColumnTransformer rejects duplicate column names; fail fast
+      # here with an actionable message instead of crashing mid-pipeline.
+      raise ValueError(
+          "X contains duplicate column names:"
+          f" {X.columns[X.columns.duplicated()].unique().tolist()}. Rename or"
+          " deduplicate them before fitting, e.g. with"
+          " X.columns = range(X.shape[1])."
+      )
 
-    for col in X.columns:
-      series = X[col]
+    datetime_pos = []
+    cat_pos = []
+    numeric_pos = []
+
+    # Classify columns by position so column labels (which may be ints or
+    # other non-strings) are never used for lookups.
+    for pos in range(X.shape[1]):
+      series = X.iloc[:, pos]
       if pd.api.types.is_datetime64_any_dtype(series.dtype):
-        datetime_cols.append(col)
+        datetime_pos.append(pos)
       elif _looks_like_datetime(series):
-        datetime_cols.append(col)
+        datetime_pos.append(pos)
       elif pd.api.types.is_numeric_dtype(series.dtype):
-        numeric_cols.append(col)
+        numeric_pos.append(pos)
       else:
         # fallback to categorical if unknown
-        cat_cols.append(col)
-
-    cat_pos = [X.columns.get_loc(col) for col in cat_cols]
-    numeric_pos = [X.columns.get_loc(col) for col in numeric_cols]
-    datetime_pos = [X.columns.get_loc(col) for col in datetime_cols]
+        cat_pos.append(pos)
 
     self.tfm_ = ColumnTransformer(
         transformers=[

--- a/tabfm/src/classifier_and_regressor_test.py
+++ b/tabfm/src/classifier_and_regressor_test.py
@@ -1045,5 +1045,40 @@ class DatetimeDetectionTest(absltest.TestCase):
     self.assertFalse(_looks_like_datetime(pd.Series(vals, dtype="string")))
 
 
+class ColumnNameRobustnessTest(absltest.TestCase):
+
+  def test_duplicate_column_names_raise_a_clear_error(self):
+    # Joins/concats commonly produce duplicate column names. sklearn's
+    # ColumnTransformer cannot process them, so fail fast with an actionable
+    # message instead of the cryptic "'DataFrame' object has no attribute
+    # 'dtype'" raised previously.
+    X = pd.DataFrame(
+        [[1.0, "x", 2.0], [3.0, "y", 4.0], [5.0, "x", 6.0]],
+        columns=["a", "b", "a"],
+    )
+
+    with self.assertRaisesRegex(ValueError, r"duplicate column names.*'a'"):
+      TransformToNumerical(min_cat_frequency=1).fit(X)
+
+  def test_classifier_fit_duplicate_column_names_raises_clear_error(self):
+    classifier = TabFMClassifier(
+        model=mock.Mock(max_classes=10), n_estimators=2
+    )
+    X = pd.DataFrame(np.random.rand(10, 2), columns=["a", "a"])
+    y = np.array([0, 1] * 5)
+
+    with self.assertRaisesRegex(ValueError, "duplicate column names"):
+      classifier.fit(X, y)
+
+  def test_datetime_column_with_non_string_name(self):
+    # DataFrames built from arrays get integer column labels; the datetime
+    # expansion used to crash on `0 + "."` when building derived names.
+    X = pd.DataFrame({0: pd.date_range("2020-01-01", periods=4, freq="D")})
+
+    out = TransformToNumerical().fit_transform(X)
+
+    self.assertEqual(out.shape, (4, 5))  # unix-ns + 4 derived features
+
+
 if __name__ == "__main__":
   absltest.main()


### PR DESCRIPTION
## Summary

Two related crashes in the sklearn layer's column-name handling, found by running an edge-case battery (NaN-heavy inputs, unseen categories, class-count limits, wide tables, odd column names, and so on) against tiny random models on CPU:

1. **Duplicate column names crash with a cryptic error.** DataFrames coming out of pandas joins/concats often carry duplicate column names. `TransformToNumerical.fit` used name-based lookups (`X[col]`, `columns.get_loc`), so fitting crashed with `AttributeError: 'DataFrame' object has no attribute 'dtype'`. sklearn's `ColumnTransformer` cannot process duplicate names either, so supporting them is not realistic; instead we fail fast with a `ValueError` that names the duplicated columns and suggests a fix.

2. **Datetime columns with non-string names crash.** `pd.DataFrame(some_array)` gives integer column labels. If such a column holds datetimes, `DatetimeTransformer.transform` crashed with `TypeError` on `feature + "."` while building the derived-feature names. Column classification and datetime expansion now work positionally end to end, which also removes the name-to-position `get_loc` round-trip. Datetime outputs are unchanged for well-formed inputs; I checked the expanded values element for element against the previous name-based logic.

## Repro on main

```python
import pandas as pd
from tabfm.src.classifier_and_regressor import TransformToNumerical

# 1) AttributeError: 'DataFrame' object has no attribute 'dtype'
TransformToNumerical().fit(pd.DataFrame([[1.0, 2.0]], columns=["a", "a"]))

# 2) TypeError: unsupported operand type(s) for +: 'int' and 'str'
TransformToNumerical().fit_transform(
    pd.DataFrame({0: pd.date_range("2020-01-01", periods=4)}))
```

## Testing

- 3 new tests (`ColumnNameRobustnessTest`); they run without any backend installed (the classifier-level test uses a mock model).
- `pytest tabfm/src/classifier_and_regressor_test.py tabfm/src/classifier_and_regressor_pytorch_test.py` passes (41 tests).
