### PR TITLE
Raise NotFittedError from TabFMRegressor.predict before fit

### DIFF
--- a/tabfm/src/classifier_and_regressor.py
+++ b/tabfm/src/classifier_and_regressor.py
@@ -3256,6 +3256,7 @@ class TabFMRegressor(RegressorMixin, BaseEstimator):
   @jt.typed
   def _predict_internal(self, X: Any) -> jt.Float[Array | np.ndarray, "E T"]:
     """Predict regression target for test samples."""
+    check_is_fitted(self)
     if isinstance(X, np.ndarray) and len(X.shape) == 1:
       raise ValueError("The provided input X is one-dimensional. Reshape your data.")
 

--- a/tabfm/src/classifier_and_regressor_test.py
+++ b/tabfm/src/classifier_and_regressor_test.py
@@ -17,6 +17,7 @@ from unittest import mock
 from absl.testing import absltest
 import numpy as np
 import pandas as pd
+from sklearn.exceptions import NotFittedError
 
 try:
   from flax import nnx
@@ -1009,6 +1010,16 @@ class LabelEncodingTest(absltest.TestCase):
     clf.fit(x, y)
     np.testing.assert_array_equal(clf.classes_, np.array(["a", "z"]))
     self.assertEqual(clf.y_encoder_.mode, "alphabetical")
+
+
+class NotFittedTest(absltest.TestCase):
+
+  def test_predict_before_fit_raises_not_fitted(self):
+    X = np.zeros((3, 2))
+    with self.assertRaises(NotFittedError):
+      TabFMRegressor(model=mock.Mock()).predict(X)
+    with self.assertRaises(NotFittedError):
+      TabFMClassifier(model=mock.Mock()).predict(X)
 
 
 class DatetimeDetectionTest(absltest.TestCase):


### PR DESCRIPTION
Calling `predict` on an unfitted `TabFMRegressor` raises `AttributeError: 'TabFMRegressor' object has no attribute 'X_encoder_'` instead of sklearn's standard `NotFittedError`. The classifier already calls `check_is_fitted` in `_predict_proba_internal`; the regressor's `_predict_internal` was missing it. This adds the same check plus a test covering both estimators.

Repro on main:

```python
from unittest import mock
from tabfm.src.classifier_and_regressor import TabFMRegressor

TabFMRegressor(model=mock.Mock()).predict([[0.0, 1.0]])
```

Testing: `pytest tabfm/src/classifier_and_regressor_test.py tabfm/src/classifier_and_regressor_pytorch_test.py` passes (39 tests).
