### PR TITLE
Make the PyTorch model picklable (module-level gelu activation)

### DIFF
--- a/tabfm/src/classifier_and_regressor_pytorch_test.py
+++ b/tabfm/src/classifier_and_regressor_pytorch_test.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import pickle
 import unittest
 from unittest import mock
 import numpy as np
@@ -99,6 +100,56 @@ class PyTorchClassifierRegressorTest(unittest.TestCase):
     # Predict
     preds = reg.predict(X)
     self.assertEqual(preds.shape, (10,))
+
+
+class PyTorchModelPickleTest(unittest.TestCase):
+  """The PyTorch model must be picklable.
+
+  AutoGluon / TabArena save the fitted estimator (which holds the model) with
+  stdlib pickle. The encode/decode heads are gelu ``MLP``s whose activation was
+  previously a lambda from ``get_activation`` -- unpicklable -- so this guards
+  against that regression. The regression path builds three such heads
+  (y_embedder, y_encoder, decoder), so it exercises the activation most.
+  """
+
+  def _tiny_model(self, is_classifier):
+    return pytorch_model.TabFM(
+        embed_dim=8,
+        max_classes=3,
+        col_num_blocks=1,
+        col_nhead=2,
+        col_num_inds=8,
+        row_num_blocks=1,
+        row_nhead=2,
+        row_num_cls=2,
+        icl_num_blocks=1,
+        icl_nhead=2,
+        ff_factor=2,
+        feature_group_size=2,
+        is_classifier=is_classifier,
+    )
+
+  def test_classifier_model_pickle_round_trip(self):
+    restored = pickle.loads(pickle.dumps(self._tiny_model(is_classifier=True)))
+    self.assertIsInstance(restored, pytorch_model.TabFM)
+
+  def test_regressor_model_pickle_round_trip(self):
+    restored = pickle.loads(pickle.dumps(self._tiny_model(is_classifier=False)))
+    self.assertIsInstance(restored, pytorch_model.TabFM)
+
+  def test_pickle_preserves_forward_output(self):
+    # The unpickled model must still run and produce identical outputs: the
+    # promoted _gelu_tanh is numerically identical to the previous lambda.
+    torch.manual_seed(0)
+    model = self._tiny_model(is_classifier=True).eval()
+    x = torch.randn(2, 4, 6)  # [B, T, H]
+    y = torch.randint(0, 3, (2, 4))  # [B, T]
+    train_size = torch.tensor([2, 3])  # [B]
+    with torch.no_grad():
+      before = model(x, y, train_size)
+      restored = pickle.loads(pickle.dumps(model)).eval()
+      after = restored(x, y, train_size)
+    torch.testing.assert_close(before, after)
 
 
 if __name__ == "__main__":

--- a/tabfm/src/pytorch/model.py
+++ b/tabfm/src/pytorch/model.py
@@ -32,10 +32,17 @@ import torch.nn.functional as F
 from torch import nn
 
 
-def get_activation(name):
+def _gelu_tanh(x):
   # jax.nn.gelu defaults to the tanh approximation -> match it.
+  return F.gelu(x, approximate="tanh")
+
+
+def get_activation(name):
+  # Activations are stored as module attributes (e.g. MLP.act), so they must be
+  # picklable for AutoGluon/TabArena's pickle-based save. A module-level
+  # function pickles by reference; a lambda would not.
   return {"relu": F.relu,
-          "gelu": lambda x: F.gelu(x, approximate="tanh"),
+          "gelu": _gelu_tanh,
           "silu": F.silu}[name]
 
 


### PR DESCRIPTION
## Problem

Pickling the PyTorch `TabFM` model fails:

```
AttributeError: Can't pickle local object 'get_activation.<locals>.<lambda>'
```

`get_activation("gelu")` returns a lambda, which is stored as `self.act` on the gelu `MLP` heads. The transformer FFNs use swiglu (`F.silu`, picklable), but every model carries at least one gelu `MLP` — the y-encoder and decoder (the regression path also adds a y-embedder) — so the model as a whole is unpicklable.

This matters because AutoGluon / TabArena save the fitted estimator (which holds the model) with stdlib pickle. TabArena currently works around it with a custom `__getstate__`/`__setstate__` that drops and reloads the network (autogluon/tabarena#434); this fix lets that workaround be removed.

Repro on `main`:

```python
import pickle
from tabfm.src.pytorch import model
m = model.TabFM(embed_dim=8, max_classes=3, col_num_blocks=1, col_nhead=2,
                col_num_inds=8, row_num_blocks=1, row_nhead=2, row_num_cls=2,
                icl_num_blocks=1, icl_nhead=2, ff_factor=2, feature_group_size=2,
                is_classifier=True)
pickle.dumps(m)  # AttributeError
```

## Fix

Promote the gelu activation to a module-level `_gelu_tanh` function. Module-level functions pickle by reference; the computation is unchanged (`F.gelu(x, approximate="tanh")`), so weights and outputs are identical — this is purely a serialization fix.

## Testing

Adds `PyTorchModelPickleTest` (torch-only): classifier and regressor model pickle round-trips, plus a forward-output equivalence check after unpickling. The regressor case exercises all three gelu `MLP` heads.

`pytest tabfm/src/classifier_and_regressor_pytorch_test.py` passes (5 tests).