### PR TITLE
Make fitted estimators picklable after predict (JAX backend)

### DIFF
--- a/tabfm/src/classifier_and_regressor.py
+++ b/tabfm/src/classifier_and_regressor.py
@@ -1816,6 +1816,14 @@ def _predict_step_pytorch(
   return out_t.float().cpu().numpy()  # upcast: numpy has no bfloat16
 
 
+# Compiled predict step functions memoized on the estimators by
+# _batch_forward. They close over nnx.jit state and cannot be pickled.
+_COMPILED_PREDICT_CACHE_ATTRS = (
+    "_predict_step_compiled_with_cat",
+    "_predict_step_compiled_no_cat",
+)
+
+
 # ---------------------------------------------------------------------------
 # Classifier
 # ---------------------------------------------------------------------------
@@ -2404,6 +2412,18 @@ class TabFMClassifier(ClassifierMixin, BaseEstimator):
         outputs.append(out)
 
       return np.concatenate(outputs, axis=0)
+
+  def __getstate__(self):
+    """Drops memoized compiled predict functions from the pickled state.
+
+    The first predict memoizes nnx.jit-compiled step functions on the
+    estimator (see _batch_forward). Those closures cannot be pickled; they
+    are pure caches and are rebuilt lazily on the next predict.
+    """
+    state = dict(super().__getstate__())
+    for attr in _COMPILED_PREDICT_CACHE_ATTRS:
+      state.pop(attr, None)
+    return state
 
   @jt.typed
   def predict_oof_proba(self, cv: int = 5) -> jt.Float[Array | np.ndarray, "E N K"]:
@@ -3175,6 +3195,18 @@ class TabFMRegressor(RegressorMixin, BaseEstimator):
   def _inverse_transform_y(self, y_scaled: np.ndarray) -> np.ndarray:
     """Inverse transform target values."""
     return self.y_scaler_.inverse_transform(y_scaled.reshape(-1, 1)).flatten()
+
+  def __getstate__(self):
+    """Drops memoized compiled predict functions from the pickled state.
+
+    The first predict memoizes nnx.jit-compiled step functions on the
+    estimator (see _batch_forward). Those closures cannot be pickled; they
+    are pure caches and are rebuilt lazily on the next predict.
+    """
+    state = dict(super().__getstate__())
+    for attr in _COMPILED_PREDICT_CACHE_ATTRS:
+      state.pop(attr, None)
+    return state
 
   @jt.typed
   def predict_oof(self, cv: int = 5) -> jt.Float[Array | np.ndarray, "E N"]:

--- a/tabfm/src/classifier_and_regressor_test.py
+++ b/tabfm/src/classifier_and_regressor_test.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import pickle
 import unittest
 from unittest import mock
 from absl.testing import absltest
@@ -1020,6 +1021,57 @@ class NotFittedTest(absltest.TestCase):
       TabFMRegressor(model=mock.Mock()).predict(X)
     with self.assertRaises(NotFittedError):
       TabFMClassifier(model=mock.Mock()).predict(X)
+
+
+@unittest.skipUnless(HAS_JAX, "JAX is required")
+class EstimatorPickleTest(absltest.TestCase):
+  """Fitted estimators must survive pickle after a predict.
+
+  AutoGluon / TabArena save the fitted estimator with stdlib pickle. The
+  first predict memoizes nnx.jit-compiled step functions on the estimator
+  (see _batch_forward); those closures cannot be pickled, so they are
+  dropped from the pickled state and rebuilt lazily after restore.
+  """
+
+  def _tiny_model(self, loss):
+    return tabfm_model.TabFM(
+        loss=loss,
+        max_classes=10,
+        embed_dim=8,
+        col_num_blocks=1,
+        col_nhead=2,
+        col_num_inds=8,
+        row_num_blocks=1,
+        row_nhead=2,
+        row_num_cls=1,
+        icl_num_blocks=1,
+        icl_nhead=2,
+        rngs=nnx.Rngs(0),
+    )
+
+  def test_classifier_pickle_round_trip_after_predict(self):
+    classifier = TabFMClassifier(
+        model=self._tiny_model("cross_entropy"), n_estimators=2
+    )
+    X = np.random.rand(12, 3)
+    X_test = np.random.rand(4, 3)
+    classifier.fit(X, np.array([0, 1] * 6))
+    proba = classifier.predict_proba(X_test)
+
+    restored = pickle.loads(pickle.dumps(classifier))
+
+    np.testing.assert_allclose(restored.predict_proba(X_test), proba)
+
+  def test_regressor_pickle_round_trip_after_predict(self):
+    regressor = TabFMRegressor(model=self._tiny_model("rmse"), n_estimators=2)
+    X = np.random.rand(12, 3)
+    X_test = np.random.rand(4, 3)
+    regressor.fit(X, np.random.rand(12))
+    preds = regressor.predict(X_test)
+
+    restored = pickle.loads(pickle.dumps(regressor))
+
+    np.testing.assert_allclose(restored.predict(X_test), preds)
 
 
 class DatetimeDetectionTest(absltest.TestCase):


### PR DESCRIPTION
## Summary

Saving a fitted estimator with stdlib pickle crashes on the JAX backend once `predict` has run:

```
AttributeError: Can't pickle local object 'TabFMClassifier._batch_forward.<locals>._predict_step_fn'
```

The first predict memoizes nnx.jit-compiled step functions on the estimator instance (`_predict_step_compiled_with_cat` / `_predict_step_compiled_no_cat`, see `_batch_forward`). Those closures cannot be pickled. This is the same save path that motivated #47 on the PyTorch side: AutoGluon / TabArena pickle the fitted estimator, and fit then predict then save is the normal order, so this breaks the JAX backend for that workflow.

The fix drops the memoized functions from `__getstate__` on both estimators. They are pure caches, guarded by `hasattr` in `_batch_forward`, so they are rebuilt lazily on the next predict; a restored estimator produces identical predictions (covered by the new tests). `dict(super().__getstate__())` is used because sklearn's `BaseEstimator.__getstate__` can hand back the live `__dict__` for estimators outside the sklearn namespace, and pickling should not evict the running object's cache as a side effect.

Pickling a fitted estimator before the first predict already worked; only the after-predict state was broken.

## Repro on main

```python
import pickle
import numpy as np
from flax import nnx
from tabfm.src.jax import model as tabfm_model
from tabfm.src.classifier_and_regressor import TabFMClassifier

model = tabfm_model.TabFM(
    loss="cross_entropy", max_classes=10, embed_dim=8, col_num_blocks=1,
    col_nhead=2, col_num_inds=8, row_num_blocks=1, row_nhead=2,
    row_num_cls=1, icl_num_blocks=1, icl_nhead=2, rngs=nnx.Rngs(0))
clf = TabFMClassifier(model=model, n_estimators=2)
X = np.random.rand(16, 3)
clf.fit(X, np.array([0, 1] * 8))
pickle.dumps(clf)          # works
clf.predict_proba(X[:4])
pickle.dumps(clf)          # AttributeError: Can't pickle local object ...
```

## Testing

- 2 new tests (`EstimatorPickleTest`): fit, predict, pickle round trip, and the restored estimator's predictions match exactly (classifier and regressor).
- Full `pytest tabfm/src/` passes (74 tests, both backends installed).
