### PR TITLE
Fix #27: Align PyTorch TabFM max_classes default with checkpoint config

### DIFF
--- a/tabfm/src/pytorch/model.py
+++ b/tabfm/src/pytorch/model.py
@@ -418,7 +418,7 @@ class ICLearning(nn.Module):
 
 
 class TabFM(nn.Module):
-  def __init__(self, *, embed_dim=8, max_classes=3, col_num_blocks=2,
+  def __init__(self, *, embed_dim=8, max_classes=10, col_num_blocks=2,
                col_nhead=2, col_num_inds=4, row_num_blocks=2, row_nhead=2,
                row_num_cls=2, icl_num_blocks=2, icl_nhead=2, ff_factor=2,
                feature_group_size=3, num_freq=32, decoder_hidden=None,


### PR DESCRIPTION
Resolves #27.

**Description:**
The `max_classes` configuration for `tabfm_v1_0_0` is correctly defined as `10` across the codebase (e.g., in the JAX model and the model checkpoints). However, the default constructor arguments for the PyTorch `TabFM` class were mistakenly set to `max_classes=3`. 

This PR updates the default PyTorch `max_classes` initialization parameter to `10` so that it seamlessly aligns with the JAX implementation and the pre-trained HuggingFace checkpoint settings.
