### PR TITLE
Fix regressor fit crash when sklearn transform_output is "pandas"

### DIFF
--- a/tabfm/src/classifier_and_regressor.py
+++ b/tabfm/src/classifier_and_regressor.py
@@ -3430,6 +3430,10 @@ class TabFMRegressor(RegressorMixin, BaseEstimator):
     cat_features = list(range(n_cat))
 
     self.y_scaler_ = StandardScaler()
+    # Keep ndarray output even if the user set a global
+    # sklearn.set_config(transform_output="pandas"): otherwise fit_transform
+    # returns a DataFrame, which has no .flatten().
+    self.y_scaler_.set_output(transform="default")
     y = self.y_scaler_.fit_transform(y.reshape(-1, 1)).flatten()
 
     self.ensemble_generator_ = EnsembleGenerator(

--- a/tabfm/src/classifier_and_regressor_test.py
+++ b/tabfm/src/classifier_and_regressor_test.py
@@ -18,6 +18,7 @@ from unittest import mock
 from absl.testing import absltest
 import numpy as np
 import pandas as pd
+from sklearn import config_context
 from sklearn.exceptions import NotFittedError
 
 try:
@@ -1198,6 +1199,26 @@ class ColumnNameRobustnessTest(absltest.TestCase):
     out = TransformToNumerical().fit_transform(X)
 
     self.assertEqual(out.shape, (4, 5))  # unix-ns + 4 derived features
+
+
+class GlobalPandasOutputTest(absltest.TestCase):
+  """Fit must ignore a user's global transform_output="pandas" config."""
+
+  def test_regressor_fit_with_pandas_output_config(self):
+    # A user who calls sklearn.set_config(transform_output="pandas") used to
+    # crash the regressor: the internal target StandardScaler returned a
+    # DataFrame, and `.flatten()` on it raised AttributeError. See issue #58.
+    regressor = TabFMRegressor(n_estimators=2, model=mock.Mock())
+
+    X = np.random.rand(10, 4)
+    y = np.random.rand(10)
+
+    with config_context(transform_output="pandas"):
+      regressor.fit(X, y)
+      # The target scaler stays pinned to ndarray output under the config.
+      scaled = regressor.y_scaler_.transform(y.reshape(-1, 1))
+
+    self.assertIsInstance(scaled, np.ndarray)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Why

`TabFMRegressor.fit` crashes for any user whose sklearn output config is set to
pandas globally:

```python
import sklearn
sklearn.set_config(transform_output="pandas")
reg.fit(X_train, y_train)
# AttributeError: 'DataFrame' object has no attribute 'flatten'
```

The target `StandardScaler` is an internal transformer. Under
`transform_output="pandas"` its `fit_transform` returns a DataFrame, and the
next line calls `.flatten()` on it, which only exists on ndarrays. That is
issue #58 (the reporter's traceback shows the matching FunctionTransformer
"pandas" warning, so the config was active in their environment).

The classifier is not affected (it does not scale the target). `predict` is not
affected either: `inverse_transform` output is not controlled by that config.

## What

Pin the internal target scaler to ndarray output with
`set_output(transform="default")`, so the regressor ignores the user's global
config for its own internal transformer. This is the standard way for a library
to keep ndarray output when it consumes transformer results directly.

Added a regression test that fits the regressor inside a
`transform_output="pandas"` context and checks it does not crash.
