### PR TITLE
Add ICL context caching for the PyTorch backend + expose in sklearn API

### DIFF
--- a/tabfm/src/classifier_and_regressor.py
+++ b/tabfm/src/classifier_and_regressor.py
@@ -49,6 +49,7 @@ except ImportError:
 
 try:
   import torch
+  from tabfm.src.pytorch.model import move_cache_to_device
   HAS_TORCH = True
 except ImportError:
   HAS_TORCH = False
@@ -1685,6 +1686,184 @@ class EnsembleGenerator(TransformerMixin, BaseEstimator):
     ds_all = np.array(ds_all, dtype=np.int32)
     return Xs_all, ys_all, cat_masks_all, ds_all, configs_flat
 
+  def prepare_test_tensors(
+      self, data: collections.OrderedDict
+  ) -> Tuple[np.ndarray, np.ndarray, np.ndarray, List[Any]]:
+    """Like prepare_ensemble_tensors(), but for test-only data (no labels).
+
+    Used by the cache_context=True decode path (see transform_test_only()),
+    where data maps norm_method -> (Xs, None) instead of (Xs, ys).
+
+    Args:
+      data: Ordered dictionary mapping normalization string keys to Xs
+        tensors (e.g., returned by transform_test_only()).
+
+    Returns:
+      Tuple containing:
+        - Xs_all: Concatenated feature array across all ensemble configs.
+        - cat_masks_all: Stacked boolean masks indicating categorical indices.
+        - ds_all: Array indicating sequence lengths per config.
+        - configs_flat: Flattened list of ensemble config tuples.
+    """
+    max_features = max(Xs.shape[-1] for _, (Xs, _) in data.items())
+    Xs_all, cat_masks_all, ds_all = [], [], []
+    configs_flat = []
+
+    for norm_method, (Xs, _) in data.items():
+      Xs_all.append(Xs)
+      configs = self.ensemble_configs_[norm_method]
+      for config in configs:
+        configs_flat.append(config)
+        shuffle_pattern, _, _, _ = config
+        mask = np.zeros(self.n_features_in_, dtype=np.bool_)
+        if hasattr(self, "cat_features_"):
+          mask[self.cat_features_] = True
+        ds_all.append(len(shuffle_pattern))
+        cat_mask = _pad_cat_mask(mask[shuffle_pattern], max_features)
+        cat_masks_all.append(cat_mask)
+
+    Xs_all = np.concatenate(Xs_all, axis=0)
+    cat_masks_all = np.stack(cat_masks_all, axis=0)
+    ds_all = np.array(ds_all, dtype=np.int32)
+    return Xs_all, cat_masks_all, ds_all, configs_flat
+
+  def transform_context_only(self) -> collections.OrderedDict:
+    """Builds per-member context-only (training-row) feature/label tensors.
+
+    Used to build a cache_context=True prefill cache at fit() time. This
+    mirrors exactly the "training rows" half of what _transform_features()
+    computes for the concatenated train+test tensor (same preprocessing,
+    same categorical-permutation handling, same shuffle pattern and
+    class-shift offset per config) but omits ever concatenating test rows.
+
+    This is correct because every preprocessor.transform() step, including
+    _apply_categorical_permutation(), is row-independent: each output row is
+    computed from that row's values and fit-time statistics, not from other
+    rows in the batch.
+
+    Returns:
+      OrderedDict mapping each norm_method to a tuple (Xs, ys) with the
+      same shapes/semantics as transform()'s "training" portion.
+    """
+    check_is_fitted(self, ["ensemble_configs_"])
+    y = self.y_
+    N = len(y)
+
+    max_features = 0
+    for (
+        norm_method,
+        shuffle_shift_cat_configs,
+    ) in self.ensemble_configs_.items():
+      for shuffle_pattern, _, _, _ in shuffle_shift_cat_configs:
+        max_features = max(max_features, len(shuffle_pattern))
+
+    data: collections.OrderedDict = collections.OrderedDict()
+    for (
+        norm_method,
+        shuffle_shift_cat_configs,
+    ) in self.ensemble_configs_.items():
+      preprocessor = self.preprocessors_[norm_method]
+      X_ensemble = []
+      y_ensemble = []
+
+      for (
+          shuffle_pattern,
+          shift_offset,
+          cat_perm,
+          row_sub_pattern,
+      ) in shuffle_shift_cat_configs:
+        in_bag_idx = (
+            row_sub_pattern if row_sub_pattern is not None else np.arange(N)
+        )
+        train_idx = in_bag_idx
+        y_to_use = y[train_idx]
+
+        if cat_perm:
+          X_train_to_use = self.X_[train_idx].copy()
+          _apply_categorical_permutation(X_train_to_use, cat_perm)
+          X_variant_instance = preprocessor.transform(X_train_to_use)
+        else:
+          X_variant_instance = preprocessor.X_transformed_[train_idx]
+
+        shuffled_cols = X_variant_instance[:, shuffle_pattern]
+        shuffled_cols = _pad_features(shuffled_cols, max_features)
+        X_ensemble.append(shuffled_cols)
+
+        if self.task == "classification":
+          y_ensemble.append((y_to_use + shift_offset) % self.n_classes_)
+        else:
+          y_ensemble.append(y_to_use)
+
+      data[norm_method] = (
+          np.stack(X_ensemble, axis=0),
+          np.stack(y_ensemble, axis=0),
+      )
+
+    return data
+
+  def transform_test_only(self, X: Any) -> collections.OrderedDict:
+    """Builds per-member test-only feature tensors (no context rows).
+
+    Used for the cache_context=True decode path at predict_proba() time.
+    Mirrors exactly the "test rows" half of what _transform_features()
+    computes for the concatenated train+test tensor (see
+    transform_context_only() for why omitting the concatenation is safe).
+
+    Args:
+      X: Array-like of shape (n_test_samples, n_features).
+
+    Returns:
+      OrderedDict mapping each norm_method to a tuple (Xs, None) where
+      Xs has shape (n_configs, n_test, n_features).
+    """
+    check_is_fitted(self, ["ensemble_configs_"])
+    X = self.unique_filter_.transform(X)
+
+    if hasattr(self, "cross_pairs_") and self.cross_pairs_:
+      X = _append_cross_features(X, self.cross_pairs_)
+
+    if hasattr(self, "svd_pipeline_") and self.svd_pipeline_:
+      X = _append_svd_features(
+          X, self.n_original_features_, self.svd_pipeline_, is_train=False
+      )
+
+    max_features = 0
+    for (
+        norm_method,
+        shuffle_shift_cat_configs,
+    ) in self.ensemble_configs_.items():
+      for shuffle_pattern, _, _, _ in shuffle_shift_cat_configs:
+        max_features = max(max_features, len(shuffle_pattern))
+
+    data: collections.OrderedDict = collections.OrderedDict()
+    for (
+        norm_method,
+        shuffle_shift_cat_configs,
+    ) in self.ensemble_configs_.items():
+      preprocessor = self.preprocessors_[norm_method]
+      X_ensemble = []
+
+      for (
+          shuffle_pattern,
+          _,
+          cat_perm,
+          _,
+      ) in shuffle_shift_cat_configs:
+        if cat_perm:
+          X_test_to_use = X.copy()
+          _apply_categorical_permutation(X_test_to_use, cat_perm)
+          X_variant_instance = preprocessor.transform(X_test_to_use)
+        else:
+          X_variant_instance = preprocessor.transform(X)
+
+        shuffled_cols = X_variant_instance[:, shuffle_pattern]
+        shuffled_cols = _pad_features(shuffled_cols, max_features)
+        X_ensemble.append(shuffled_cols)
+
+      data[norm_method] = (np.stack(X_ensemble, axis=0), None)
+
+    return data
+
 
 # ---------------------------------------------------------------------------
 # Shared helpers
@@ -1826,8 +2005,168 @@ def _predict_step_pytorch(
   return out_t.float().cpu().numpy()  # upcast: numpy has no bfloat16
 
 
+def _build_context_cache_pytorch(
+    model: Any,
+    ensemble_generator: "EnsembleGenerator",
+    batch_size: Optional[int],
+    maybe_quantize_kv_cache: bool = True,
+    keep_cache_on_device: bool = True,
+) -> Tuple[List[Any], int]:
+  """Prefills each ensemble member's in-context (training) rows once.
+
+  Shared by TabFMClassifier._build_context_cache() and
+  TabFMRegressor._build_context_cache() (cache_context=True). Runs
+  model.prefill() once per ensemble member, batched the same way
+  _batch_forward() batches the uncached forward pass (via batch_size).
+
+  Args:
+    model: PyTorch TabFM nn.Module.
+    ensemble_generator: Fitted EnsembleGenerator.
+    batch_size: Number of ensemble members per model.prefill() call (None
+      or 0 means all at once).
+    maybe_quantize_kv_cache: If True (default) and the cache supports it
+      (ICLearningCache.quantize()), int8-quantize the ICL K/V right after
+      prefill to reduce the resident memory of holding every ensemble
+      member's cache on-device at once.
+    keep_cache_on_device: If True (default), keep each cache on the model's
+      device. If False, move it to CPU right after building (traded for
+      lower steady-state device memory at the cost of a transfer on every
+      predict call; see _decode_context_cache_pytorch()).
+
+  Returns:
+    Tuple of (caches, n_members): caches is the list of per-batch cache
+    dicts returned by model.prefill(), and n_members is the total number
+    of ensemble members (used later to detect a stale cache).
+  """
+  data_ctx = ensemble_generator.transform_context_only()
+  Xs_ctx, ys_ctx, cat_masks_ctx, ds_ctx, _ = (
+      ensemble_generator.prepare_ensemble_tensors(data_ctx)
+  )
+
+  n_members = Xs_ctx.shape[0]
+  batch_size_per_process = batch_size or n_members
+  n_batches = math.ceil(n_members / batch_size_per_process)
+  if n_batches > 1:
+    Xs_split = np.array_split(Xs_ctx, n_batches)
+    ys_split = np.array_split(ys_ctx, n_batches)
+    cat_masks_split = np.array_split(cat_masks_ctx, n_batches)
+    ds_split = np.array_split(ds_ctx, n_batches)
+  else:
+    Xs_split = [Xs_ctx]
+    ys_split = [ys_ctx]
+    cat_masks_split = [cat_masks_ctx]
+    ds_split = [ds_ctx]
+
+  device = next(model.parameters()).device
+  caches = []
+  with torch.no_grad():
+    for X_batch, y_batch, cat_mask_batch, ds_batch in zip(
+        Xs_split, ys_split, cat_masks_split, ds_split
+    ):
+      X_t = torch.from_numpy(X_batch).to(device, dtype=torch.float32)
+      y_t = torch.from_numpy(y_batch).to(device)
+      if y_t.dtype == torch.float64:
+        y_t = y_t.to(torch.float32)
+      cat_mask_t = torch.from_numpy(cat_mask_batch).to(device)
+      d_t = torch.from_numpy(ds_batch).to(device)
+      _, cache = model.prefill(X_t, y_t, cat_mask=cat_mask_t, d=d_t)
+      icl_cache = cache.get("icl")
+      if maybe_quantize_kv_cache and hasattr(icl_cache, "quantize"):
+        cache["icl"] = icl_cache.quantize()
+      if not keep_cache_on_device:
+        cache = move_cache_to_device(cache, "cpu")
+      caches.append(cache)
+
+  return caches, n_members
+
+
+def _decode_context_cache_pytorch(
+    model: Any,
+    ensemble_generator: "EnsembleGenerator",
+    X_transformed: np.ndarray,
+    context_caches: List[Any],
+    expected_n_members: int,
+    batch_size: Optional[int],
+    keep_cache_on_device: bool = True,
+) -> np.ndarray:
+  """Decodes test rows against a context cache from _build_context_cache_pytorch().
+
+  Shared by TabFMClassifier._predict_proba_internal_cached() and
+  TabFMRegressor._predict_internal_cached(). Builds test-only feature
+  tensors (via transform_test_only(), which does not concatenate the
+  training context) and calls model.decode() per ensemble-member batch
+  against its cached context, using the same batching as
+  _build_context_cache_pytorch()/_batch_forward(). model.decode() dequantizes
+  any int8-quantized K/V internally (see MultiheadAttention.forward()).
+
+  Args:
+    model: PyTorch TabFM nn.Module.
+    ensemble_generator: Fitted EnsembleGenerator.
+    X_transformed: Already-X_encoder_-transformed test features.
+    context_caches: List of per-batch cache dicts from
+      _build_context_cache_pytorch().
+    expected_n_members: Total ensemble member count recorded at fit() time.
+    batch_size: Number of ensemble members per model.decode() call.
+    keep_cache_on_device: If False, each batch's cache was moved to CPU by
+      _build_context_cache_pytorch(); move it back to the model's device for
+      this call.
+
+  Returns:
+    np.ndarray of shape (n_members, n_test, output_dim).
+
+  Raises:
+    RuntimeError: If the ensemble member count changed since fit(), or the
+      batch grouping does not match the cached batches.
+  """
+  data_test = ensemble_generator.transform_test_only(X_transformed)
+  Xs_test, cat_masks_test, ds_test, _ = (
+      ensemble_generator.prepare_test_tensors(data_test)
+  )
+
+  n_members = Xs_test.shape[0]
+  if n_members != expected_n_members:
+    raise RuntimeError(
+        f"Number of ensemble members changed between fit() ({expected_n_members})"
+        f" and predict() ({n_members}); the context cache is stale."
+    )
+
+  batch_size_per_process = batch_size or n_members
+  n_batches = math.ceil(n_members / batch_size_per_process)
+  if n_batches > 1:
+    Xs_split = np.array_split(Xs_test, n_batches)
+    cat_masks_split = np.array_split(cat_masks_test, n_batches)
+    ds_split = np.array_split(ds_test, n_batches)
+  else:
+    Xs_split = [Xs_test]
+    cat_masks_split = [cat_masks_test]
+    ds_split = [ds_test]
+
+  if len(Xs_split) != len(context_caches):
+    raise RuntimeError(
+        "Batch grouping mismatch between fit()-time context cache"
+        f" ({len(context_caches)} groups) and predict()"
+        f" ({len(Xs_split)} groups); this should not happen because both"
+        " use the same total member count and batch_size."
+    )
+
+  device = next(model.parameters()).device
+  outputs = []
+  with torch.no_grad():
+    for X_batch, cat_mask_batch, ds_batch, cache in zip(
+        Xs_split, cat_masks_split, ds_split, context_caches
+    ):
+      X_t = torch.from_numpy(X_batch).to(device, dtype=torch.float32)
+      cat_mask_t = torch.from_numpy(cat_mask_batch).to(device)
+      d_t = torch.from_numpy(ds_batch).to(device)
+      if not keep_cache_on_device:
+        cache = move_cache_to_device(cache, device)
+      out_t = model.decode(X_t, cache, cat_mask=cat_mask_t, d=d_t)
+      outputs.append(out_t.float().cpu().numpy())
+  return np.concatenate(outputs, axis=0)
+
+
 # Compiled predict step functions memoized on the estimators by
-# _batch_forward. They close over nnx.jit state and cannot be pickled.
+# _batch_forward(). They close over nnx.jit state and cannot be pickled.
 _COMPILED_PREDICT_CACHE_ATTRS = (
     "_predict_step_compiled_with_cat",
     "_predict_step_compiled_no_cat",
@@ -1939,6 +2278,9 @@ class TabFMClassifier(ClassifierMixin, BaseEstimator):
       nnls_beta: float = 0.75,
       calibration_lambda: float = 1e-2,
       min_rows_for_single_val_split: int = 2000,
+      cache_context: bool = False,
+      maybe_quantize_kv_cache: bool = True,
+      keep_cache_on_device: bool = True,
   ):
     """Initialises the classifier.
 
@@ -1982,6 +2324,25 @@ class TabFMClassifier(ClassifierMixin, BaseEstimator):
       min_rows_for_single_val_split: Minimum validation rows required to allow
         learning ensemble/calibration weights on a single train/val split
         instead of full CV. 0 means always doing full CV.
+      cache_context: If True, encode the in-context (training) rows once per
+        ensemble member at fit() time and reuse that cache (per-layer K/V
+        and column-embedder induced-point reprs) on every predict_proba()
+        call, instead of re-encoding the full context on every call.
+        With maybe_quantize_kv_cache=False, the cached path is a pure speedup:
+        results are numerically identical (within floating point) to
+        cache_context=False. Only supported on the PyTorch backend; raises
+        NotImplementedError for JAX models.
+      maybe_quantize_kv_cache: If True (default) and cache_context=True,
+        int8-quantize each ensemble member's cached ICL K/V right after
+        fit() builds it (per-tensor symmetric quantization). This lets every
+        member's cache stay resident on the GPU at once without exhausting
+        device memory; it introduces small int8 rounding error, typically
+        negligible for reported metrics. Ignored when cache_context=False.
+      keep_cache_on_device: If True (default), keep every ensemble member's
+        context cache on the model's device between predict_proba() calls. If
+        False, caches are moved to CPU after fit() and transferred back to the
+        device on every predict_proba() call, trading latency for lower
+        steady-state device memory. Ignored when cache_context=False.
     """
     self.model = model
     self.n_estimators = n_estimators
@@ -2009,6 +2370,9 @@ class TabFMClassifier(ClassifierMixin, BaseEstimator):
     self.nnls_beta = nnls_beta
     self.calibration_lambda = calibration_lambda
     self.min_rows_for_single_val_split = min_rows_for_single_val_split
+    self.cache_context = cache_context
+    self.maybe_quantize_kv_cache = maybe_quantize_kv_cache
+    self.keep_cache_on_device = keep_cache_on_device
     if self.average_logits and self.enable_nnls:
       raise ValueError("average_logits and enable_nnls cannot both be True.")
     if self.max_num_rows is not None and self.enable_nnls:
@@ -2135,6 +2499,9 @@ class TabFMClassifier(ClassifierMixin, BaseEstimator):
     )
     self.ensemble_generator_.fit(X, y)
 
+    if self.cache_context:
+      self._build_context_cache()
+
     oof_probs_fit = None
     if self.enable_nnls or (
         self.active_calibration_method_ is not None
@@ -2192,6 +2559,85 @@ class TabFMClassifier(ClassifierMixin, BaseEstimator):
       self._fit_calibration(P, y_fit)
 
     return self
+
+  def _build_context_cache(self) -> None:
+    """Prefills and caches each ensemble member's in-context (training) rows.
+
+    Called from fit() when cache_context=True. Runs model.prefill()
+    once per ensemble member (batched the same way _batch_forward() batches
+    the uncached forward pass, via self.batch_size) and stores the
+    resulting caches on self.context_caches_, alongside the per-member
+    categorical masks / active-feature counts needed to later decode test
+    rows against those caches (see _predict_proba_internal_cached()).
+
+    Only supported on the PyTorch backend: the JAX backend's prefill()/
+    decode() are not wired up here (this classifier's caching path assumes
+    the PyTorch TabFM.prefill()/decode() cache/tensor contracts).
+
+    Raises:
+      NotImplementedError: If self.model is not a PyTorch nn.Module.
+    """
+    is_torch = HAS_TORCH and isinstance(self.model, torch.nn.Module)
+    if not is_torch:
+      raise NotImplementedError(
+          "cache_context=True is only implemented for the PyTorch TabFM"
+          " backend; the JAX backend's prefill()/decode() are not wired up"
+          " here yet."
+      )
+
+    self.context_caches_, self._context_n_members_ = (
+        _build_context_cache_pytorch(
+            self.model, self.ensemble_generator_, self.batch_size,
+            maybe_quantize_kv_cache=self.maybe_quantize_kv_cache,
+            keep_cache_on_device=self.keep_cache_on_device,
+        )
+    )
+
+  def _predict_proba_internal_cached(
+      self, X_transformed: np.ndarray
+  ) -> np.ndarray:
+    """cache_context=True counterpart of _predict_proba_internal().
+
+    Builds test-only feature tensors (via transform_test_only(), which does
+    not concatenate the training context) and decodes each ensemble member's
+    test chunk against its cached context, built once by
+    _build_context_cache() at fit() time. It reuses the same batching,
+    class-shift correction, and output-dim checks as the uncached path.
+
+    Args:
+      X_transformed: Already-X_encoder_-transformed test features.
+
+    Returns:
+      Array of shape (n_estimators_total, n_test_samples, n_classes) of raw
+      (class-shift-corrected) logits, matching _predict_proba_internal()'s
+      return contract.
+    """
+    if not hasattr(self, "context_caches_"):
+      raise RuntimeError(
+          "cache_context=True but no context cache was found; call fit()"
+          " first."
+      )
+
+    outputs = _decode_context_cache_pytorch(
+        self.model, self.ensemble_generator_, X_transformed,
+        self.context_caches_, self._context_n_members_, self.batch_size,
+        keep_cache_on_device=self.keep_cache_on_device,
+    )
+
+    _check_classifier_output_dim(outputs.shape[-1], self.n_classes_)
+    outputs = outputs[..., :self.n_classes_]
+
+    class_shift_offsets = []
+    for offsets in self.ensemble_generator_.class_shift_offsets_.values():
+      class_shift_offsets.extend(offsets)
+
+    all_logits = []
+    for i, offset in enumerate(class_shift_offsets):
+      out = outputs[i]
+      out = np.concatenate([out[..., offset:], out[..., :offset]], axis=-1)
+      all_logits.append(out)
+
+    return np.stack(all_logits, axis=0)
 
   @jt.typed
   def _batch_forward(
@@ -2468,7 +2914,7 @@ class TabFMClassifier(ClassifierMixin, BaseEstimator):
     """Drops memoized compiled predict functions from the pickled state.
 
     The first predict memoizes nnx.jit-compiled step functions on the
-    estimator (see _batch_forward). Those closures cannot be pickled; they
+    estimator (see _batch_forward()). Those closures cannot be pickled; they
     are pure caches and are rebuilt lazily on the next predict.
     """
     state = dict(super().__getstate__())
@@ -2668,6 +3114,10 @@ class TabFMClassifier(ClassifierMixin, BaseEstimator):
       )
 
     X_transformed = self.X_encoder_.transform(X)
+
+    if getattr(self, "cache_context", False):
+      return self._predict_proba_internal_cached(X_transformed)
+
     data = self.ensemble_generator_.transform(X_transformed)
     (
         Xs_all,
@@ -2834,6 +3284,9 @@ class TabFMRegressor(RegressorMixin, BaseEstimator):
       enable_nnls: bool = False,
       nnls_beta: float = 0.75,
       min_rows_for_single_val_split: int = 2000,
+      cache_context: bool = False,
+      maybe_quantize_kv_cache: bool = True,
+      keep_cache_on_device: bool = True,
   ):
     """Initialises the regressor.
 
@@ -2866,6 +3319,25 @@ class TabFMRegressor(RegressorMixin, BaseEstimator):
       min_rows_for_single_val_split: Minimum validation rows required to allow
         learning ensemble weights on a single train/val split instead of full
         CV. 0 means always doing full CV.
+      cache_context: If True, encode the in-context (training) rows once per
+        ensemble member at fit() time and reuse that cache (per-layer K/V
+        and column-embedder induced-point reprs) on every predict() call,
+        instead of re-encoding the full context on every call.
+        With maybe_quantize_kv_cache=False, the cached path is a pure speedup:
+        results are numerically identical (within floating point) to
+        cache_context=False. Only supported on the PyTorch backend; raises
+        NotImplementedError for JAX models.
+      maybe_quantize_kv_cache: If True (default) and cache_context=True,
+        int8-quantize each ensemble member's cached ICL K/V right after
+        fit() builds it (per-tensor symmetric quantization). This lets every
+        member's cache stay resident on the GPU at once without exhausting
+        device memory; it introduces small int8 rounding error, typically
+        negligible for reported metrics. Ignored when cache_context=False.
+      keep_cache_on_device: If True (default), keep every ensemble member's
+        context cache on the model's device between predict() calls. If False,
+        caches are moved to CPU after fit() and transferred back to the device
+        on every predict() call, trading latency for lower steady-state
+        device memory. Ignored when cache_context=False.
     """
     self.model = model
     self.n_estimators = n_estimators
@@ -2887,6 +3359,9 @@ class TabFMRegressor(RegressorMixin, BaseEstimator):
     self.enable_nnls = enable_nnls
     self.nnls_beta = nnls_beta
     self.min_rows_for_single_val_split = min_rows_for_single_val_split
+    self.cache_context = cache_context
+    self.maybe_quantize_kv_cache = maybe_quantize_kv_cache
+    self.keep_cache_on_device = keep_cache_on_device
     if self.max_num_rows is not None and self.enable_nnls:
       raise ValueError(
           "max_num_rows and enable_nnls cannot both be set at this time."
@@ -2975,6 +3450,9 @@ class TabFMRegressor(RegressorMixin, BaseEstimator):
     )
     self.ensemble_generator_.fit(X, y)
 
+    if self.cache_context:
+      self._build_context_cache()
+
     if self.enable_nnls:
       self.y_oof_scaled_ = self._compute_oof_preds_scaled(
           cv=self.num_folds_for_cv
@@ -3004,6 +3482,71 @@ class TabFMRegressor(RegressorMixin, BaseEstimator):
       )
 
     return self
+
+  def _build_context_cache(self) -> None:
+    """Prefills and caches each ensemble member's in-context (training) rows.
+
+    Called from fit() when cache_context=True. Mirrors
+    TabFMClassifier._build_context_cache() via the shared
+    _build_context_cache_pytorch() helper: runs model.prefill() once
+    per ensemble member (batched the same way _batch_forward() batches the
+    uncached forward pass, via self.batch_size) and stores the resulting
+    caches on self.context_caches_ for later decoding of test rows (see
+    _predict_internal_cached()).
+
+    Only supported on the PyTorch backend: the JAX backend's prefill()/
+    decode() are not wired up here (this regressor's caching path assumes
+    the PyTorch TabFM.prefill()/decode() cache/tensor contracts).
+
+    Raises:
+      NotImplementedError: If self.model is not a PyTorch nn.Module.
+    """
+    is_torch = HAS_TORCH and isinstance(self.model, torch.nn.Module)
+    if not is_torch:
+      raise NotImplementedError(
+          "cache_context=True is only implemented for the PyTorch TabFM"
+          " backend; the JAX backend's prefill()/decode() are not wired up"
+          " here yet."
+      )
+
+    self.context_caches_, self._context_n_members_ = (
+        _build_context_cache_pytorch(
+            self.model, self.ensemble_generator_, self.batch_size,
+            maybe_quantize_kv_cache=self.maybe_quantize_kv_cache,
+            keep_cache_on_device=self.keep_cache_on_device,
+        )
+    )
+
+  def _predict_internal_cached(
+      self, X_transformed: np.ndarray
+  ) -> np.ndarray:
+    """cache_context=True counterpart of _predict_internal().
+
+    Decodes each ensemble member's test chunk against its cached context
+    (built once by _build_context_cache() at fit() time) via the shared
+    _decode_context_cache_pytorch() helper, then squeezes the trailing
+    singleton output dimension exactly as _predict_internal() does.
+
+    Args:
+      X_transformed: Already-X_encoder_-transformed test features.
+
+    Returns:
+      Array of shape (n_estimators_total, n_test_samples) of scaled
+      predictions, matching _predict_internal()'s return contract.
+    """
+    if not hasattr(self, "context_caches_"):
+      raise RuntimeError(
+          "cache_context=True but no context cache was found; call fit()"
+          " first."
+      )
+
+    outputs = _decode_context_cache_pytorch(
+        self.model, self.ensemble_generator_, X_transformed,
+        self.context_caches_, self._context_n_members_, self.batch_size,
+        keep_cache_on_device=self.keep_cache_on_device,
+    )
+    _check_regressor_output_dim(outputs.shape[-1])
+    return outputs.squeeze(-1)
 
   @jt.typed
   def _batch_forward(
@@ -3253,7 +3796,7 @@ class TabFMRegressor(RegressorMixin, BaseEstimator):
     """Drops memoized compiled predict functions from the pickled state.
 
     The first predict memoizes nnx.jit-compiled step functions on the
-    estimator (see _batch_forward). Those closures cannot be pickled; they
+    estimator (see _batch_forward()). Those closures cannot be pickled; they
     are pure caches and are rebuilt lazily on the next predict.
     """
     state = dict(super().__getstate__())
@@ -3347,6 +3890,10 @@ class TabFMRegressor(RegressorMixin, BaseEstimator):
       raise ValueError("The provided input X is one-dimensional. Reshape your data.")
 
     X_transformed = self.X_encoder_.transform(X)
+
+    if getattr(self, "cache_context", False):
+      return self._predict_internal_cached(X_transformed)
+
     data = self.ensemble_generator_.transform(X_transformed)
     (
         Xs_all,

--- a/tabfm/src/classifier_and_regressor_pytorch_test.py
+++ b/tabfm/src/classifier_and_regressor_pytorch_test.py
@@ -66,6 +66,24 @@ class PyTorchClassifierRegressorTest(unittest.TestCase):
     self.assertEqual(probs.shape, (10, 3))
     np.testing.assert_allclose(np.sum(probs, axis=1), 1.0, rtol=1e-5)
 
+    # cache_context=True should be a pure speedup: predict_proba should match
+    # the uncached path exactly. maybe_quantize_kv_cache=False isolates this
+    # from the (lossy by design) int8 KV-cache quantization, which is tested
+    # separately in model_test.py.
+    cached_clf = TabFMClassifier(
+        model=model,
+        n_estimators=2,
+        batch_size=2,
+        random_state=42,
+        cache_context=True,
+        maybe_quantize_kv_cache=False,
+    )
+    cached_clf.fit(X, y)
+    probs_cached = cached_clf.predict_proba(X)
+    self.assertEqual(probs_cached.shape, (10, 3))
+    np.testing.assert_allclose(np.sum(probs_cached, axis=1), 1.0, rtol=1e-5)
+    np.testing.assert_allclose(probs_cached, probs, rtol=1e-5, atol=1e-6)
+
   def test_regressor_fit_predict(self):
     np.random.seed(42)
     # Instantiate small PyTorch model
@@ -96,10 +114,27 @@ class PyTorchClassifierRegressorTest(unittest.TestCase):
     y = np.random.rand(10)
 
     reg.fit(X, y)
-    
+
     # Predict
     preds = reg.predict(X)
     self.assertEqual(preds.shape, (10,))
+
+    # cache_context=True should be a pure speedup: predict should match the
+    # uncached path exactly. maybe_quantize_kv_cache=False isolates this from
+    # the (lossy by design) int8 KV-cache quantization, which is tested
+    # separately in model_test.py.
+    cached_reg = TabFMRegressor(
+        model=model,
+        n_estimators=2,
+        batch_size=2,
+        random_state=42,
+        cache_context=True,
+        maybe_quantize_kv_cache=False,
+    )
+    cached_reg.fit(X, y)
+    preds_cached = cached_reg.predict(X)
+    self.assertEqual(preds_cached.shape, (10,))
+    np.testing.assert_allclose(preds_cached, preds, rtol=1e-5, atol=1e-6)
 
 
 class PyTorchModelPickleTest(unittest.TestCase):

--- a/tabfm/src/pytorch/__init__.py
+++ b/tabfm/src/pytorch/__init__.py
@@ -1,0 +1,1 @@
+# tabfm src pytorch package

--- a/tabfm/src/pytorch/model.py
+++ b/tabfm/src/pytorch/model.py
@@ -24,8 +24,9 @@ NOT yet wired to Orbax weights; see torch_parity_harness.py for the converter
 and parity gates.
 """
 
+import dataclasses
 import math
-from typing import List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 import torch
 import torch.nn.functional as F
@@ -108,26 +109,54 @@ class MultiheadAttention(nn.Module):
     self.key_ln = RMSNorm(self.hd)
     self.per_dim_scale = nn.Parameter(torch.zeros(self.hd))
 
-  def forward(self, query, key, value, attn_mask=None, rope=None):
+  def forward(self, query, key, value, attn_mask=None, rope=None,
+              cached_kv=None, return_kv=False):
+    """Computes multi-head attention, optionally with a K/V cache.
+
+    At most one of cached_kv, return_kv is set. cached_kv is a (k, v) tuple of
+    already-projected (and, where used, rotated and key-normalized) tensors of
+    shape [B, T_src, N, D] from a prior call; key and value are then None and
+    their projections are skipped. return_kv returns the freshly computed
+    (k, v) in that layout for a later call to reuse.
+    """
     b, tq, d = query.shape
     q = self.q_proj(query).view(b, tq, self.nhead, self.hd)
-    k = self.k_proj(key).view(b, key.shape[1], self.nhead, self.hd)
-    v = self.v_proj(value).view(b, value.shape[1], self.nhead, self.hd)
+
+    if cached_kv is not None:
+      assert key is None and value is None, (
+          "key/value must be None when cached_kv is provided.")
+      cached_k, cached_v = cached_kv
+      # Cached K/V may be int8-quantized; dequantize to compute dtype before use.
+      k = cached_k.dequantize(q.dtype) if isinstance(cached_k, QuantizedTensor) else cached_k
+      v = cached_v.dequantize(q.dtype) if isinstance(cached_v, QuantizedTensor) else cached_v
+    else:
+      assert key is not None and value is not None, (
+          "key/value must not be None when cached_kv is absent.")
+      k = self.k_proj(key).view(b, key.shape[1], self.nhead, self.hd)
+      v = self.v_proj(value).view(b, value.shape[1], self.nhead, self.hd)
+
     if self.rope_base is not None:
-      # Use the Encoder's shared RoPE (checkpoint-loaded freqs) when provided;
-      # fall back to recomputing only if absent.
-      if rope is not None:
-        q, k = rope.rotate(q), rope.rotate(k)
-      else:
-        q, k = rope_interleaved(q, self.rope_base), rope_interleaved(k, self.rope_base)
-    q, k = self.query_ln(q), self.key_ln(k)
+      # Cached K is already post-RoPE, so only rotate freshly-computed K.
+      q = rope.rotate(q) if rope is not None else rope_interleaved(q, self.rope_base)
+      if cached_kv is None:
+        k = rope.rotate(k) if rope is not None else rope_interleaved(k, self.rope_base)
+
+    q = self.query_ln(q)
+    if cached_kv is None:
+      k = self.key_ln(k)
     # per-dim scale in float32 (softplus), then cast to compute dtype -- matches JAX PerDimScale.
     scale = 1.442695041 / math.sqrt(self.hd) * F.softplus(self.per_dim_scale.float())
     q = q * scale.to(q.dtype)
+
+    new_k, new_v = k, v  # cache format: [B, T_src, N, D], pre-transpose.
+
     q, k, v = (z.transpose(1, 2) for z in (q, k, v))  # [B,N,T,D]
     # bf16 SDPA (flash already does the softmax in float32 internally).
     o = F.scaled_dot_product_attention(q, k, v, attn_mask=attn_mask, scale=1.0)
-    return self.out_proj(o.transpose(1, 2).reshape(b, tq, d))
+    out = self.out_proj(o.transpose(1, 2).reshape(b, tq, d))
+    if return_kv:
+      return out, (new_k, new_v)
+    return out
 
 
 class MultiheadAttentionBlock(nn.Module):
@@ -169,13 +198,30 @@ class MultiheadAttentionBlock(nn.Module):
       out[s:s + self.ffn_chunk_size] = self._ff_impl(flat[s:s + self.ffn_chunk_size])
     return out.reshape(shape)
 
-  def forward(self, q, k=None, v=None, attn_mask=None, rope=None):
-    k = q if k is None else k
-    v = q if v is None else v
-    a = self.post_attn_ln(self.attn(self.pre_attn_ln(q), self.pre_attn_ln(k),
-                                    self.pre_attn_ln(v), attn_mask, rope=rope))
+  def forward(self, q, k=None, v=None, attn_mask=None, rope=None,
+              cached_kv=None, return_kv=False):
+    q_n = self.pre_attn_ln(q)
+    if cached_kv is not None:
+      assert k is None and v is None, (
+          "k/v must be None when cached_kv is provided.")
+      k_n, v_n = None, None
+    else:
+      k = q if k is None else k
+      v = q if v is None else v
+      k_n = self.pre_attn_ln(k)
+      v_n = self.pre_attn_ln(v)
+    attn_res = self.attn(q_n, k_n, v_n, attn_mask, rope=rope,
+                          cached_kv=cached_kv, return_kv=return_kv)
+    if return_kv:
+      attn_out, new_kv = attn_res
+    else:
+      attn_out = attn_res
+    a = self.post_attn_ln(attn_out)
     x = q + a
-    return x + self._ff(x)
+    x = x + self._ff(x)
+    if return_kv:
+      return x, new_kv
+    return x
 
 
 class InducedSelfAttentionBlock(nn.Module):
@@ -185,10 +231,22 @@ class InducedSelfAttentionBlock(nn.Module):
     self.mab1 = MultiheadAttentionBlock(d_model, nhead, dim_ff, activation)
     self.mab2 = MultiheadAttentionBlock(d_model, nhead, dim_ff, activation)
 
-  def forward(self, src, attn_mask=None):
-    ind = self.ind_vectors.unsqueeze(0).expand(src.shape[0], -1, -1)
-    hidden = self.mab1(ind, src, src, attn_mask=attn_mask)
-    return self.mab2(src, hidden, hidden)
+  def forward(self, src, attn_mask=None, cached_hidden=None, return_hidden=False):
+    """Applies induced self-attention, optionally reusing a cached hidden.
+
+    If cached_hidden (the mab1 output from a prior call) is given, mab1 is
+    skipped and only mab2 runs; return_hidden returns the freshly computed
+    hidden for a later call to reuse.
+    """
+    if cached_hidden is not None:
+      hidden = cached_hidden
+    else:
+      ind = self.ind_vectors.unsqueeze(0).expand(src.shape[0], -1, -1)
+      hidden = self.mab1(ind, src, src, attn_mask=attn_mask)
+    out = self.mab2(src, hidden, hidden)
+    if return_hidden:
+      return out, hidden
+    return out
 
 
 class Encoder(nn.Module):
@@ -202,7 +260,24 @@ class Encoder(nn.Module):
         for _ in range(num_blocks)
     ])
 
-  def forward(self, x, attn_mask=None):
+  def forward(self, x, attn_mask=None, cached_kv=None, return_kv=False):
+    """Runs the stacked attention blocks, optionally with a per-block K/V cache.
+
+    cached_kv, if given, is a per-block list of (k, v) that each block uses in
+    place of its k/v projections; return_kv collects the freshly computed
+    per-block (k, v). At most one of the two is set.
+    """
+    if cached_kv is not None:
+      assert not return_kv, "Cannot both use cached_kv and return_kv."
+      for blk, kv in zip(self.blocks, cached_kv):
+        x = blk(x, attn_mask=attn_mask, rope=self.rope, cached_kv=kv)
+      return x
+    if return_kv:
+      kvs = []
+      for blk in self.blocks:
+        x, kv = blk(x, attn_mask=attn_mask, rope=self.rope, return_kv=True)
+        kvs.append(kv)
+      return x, kvs
     for blk in self.blocks:
       x = blk(x, attn_mask=attn_mask, rope=self.rope)
     return x
@@ -217,7 +292,24 @@ class SetTransformer(nn.Module):
         for _ in range(num_blocks)
     ])
 
-  def forward(self, src, attn_mask=None):
+  def forward(self, src, attn_mask=None, cached_hidden=None, return_hidden=False):
+    """Runs the stacked induced-attention blocks.
+
+    cached_hidden, if given, is a per-block list of cached mab1 outputs (see
+    InducedSelfAttentionBlock.forward()); return_hidden=True collects the
+    freshly computed per-block hidden reprs for later reuse.
+    """
+    if cached_hidden is not None:
+      assert not return_hidden, "Cannot both use cached_hidden and return_hidden."
+      for blk, h in zip(self.blocks, cached_hidden):
+        src = blk(src, cached_hidden=h)
+      return src
+    if return_hidden:
+      hiddens = []
+      for blk in self.blocks:
+        src, h = blk(src, attn_mask=attn_mask, return_hidden=True)
+        hiddens.append(h)
+      return src, hiddens
     for blk in self.blocks:
       src = blk(src, attn_mask=attn_mask)
     return src
@@ -344,15 +436,61 @@ class ColEmbedding(nn.Module):
     self.ln_w = RMSNorm(d_model)
     self.col_chunk_size = None  # chunk the independent column axis (B*HC)
 
-  def _stage(self, src, mask):
-    return self.ln_w(self.out_w(self.tf_col(src, attn_mask=mask)))
+  def _stage(self, src, mask=None, cached_hidden=None, return_hidden=False):
+    out = self.tf_col(src, attn_mask=mask, cached_hidden=cached_hidden,
+                       return_hidden=return_hidden)
+    if return_hidden:
+      out, hidden = out
+      return self.ln_w(self.out_w(out)), hidden
+    return self.ln_w(self.out_w(out))
 
-  def forward(self, x, train_size):  # x: [B,T,HC,E]
+  def forward(self, x, train_size, *, cached_repr=None, return_repr=False):
+    """Transform input table into column-wise embeddings.
+
+    train_size is None exactly when cached_repr is given (decode): cached_repr
+    supplies the induced-point hidden, so mab1 and its mask are skipped.
+    cached_repr and return_repr are mutually exclusive.
+    """
+    assert not (cached_repr is not None and return_repr), (
+        "Cannot have both cached_repr not None and return_repr True.")
+    assert (cached_repr is not None) == (train_size is None), (
+        "train_size must be None iff cached_repr is given.")
     b, t, hc, e = x.shape
     src = x.permute(0, 2, 1, 3).reshape(b * hc, t, e)  # [B*HC, T, E]
+    cc = self.col_chunk_size
+
+    if cached_repr is not None:  # Decode: reuse cached induced-point hidden.
+      if cc is None or src.shape[0] <= cc:
+        out = self._stage(src, None, cached_hidden=cached_repr)
+      else:
+        parts = []
+        for s in range(0, src.shape[0], cc):
+          chunk_repr = [h[s:s + cc] for h in cached_repr]
+          parts.append(self._stage(src[s:s + cc], None, cached_hidden=chunk_repr))
+        out = torch.cat(parts, dim=0)
+      return out.reshape(b, hc, t, e).permute(0, 2, 1, 3)
+
     ts = train_size.repeat_interleave(hc)  # [B*HC]
     mask = (torch.arange(t, device=x.device)[None, :] < ts[:, None])[:, None, None, :]
-    cc = self.col_chunk_size
+
+    if return_repr:  # Prefill: also return the induced-point hidden per block.
+      if cc is None or src.shape[0] <= cc:
+        out, hidden = self._stage(src, mask, return_hidden=True)
+      else:
+        out_parts = []
+        hidden_parts = None
+        for s in range(0, src.shape[0], cc):
+          o, h = self._stage(src[s:s + cc], mask[s:s + cc], return_hidden=True)
+          out_parts.append(o)
+          if hidden_parts is None:
+            hidden_parts = [[] for _ in h]
+          for i, hh in enumerate(h):
+            hidden_parts[i].append(hh)
+        out = torch.cat(out_parts, dim=0)
+        hidden = [torch.cat(parts, dim=0) for parts in hidden_parts]
+      out = out.reshape(b, hc, t, e).permute(0, 2, 1, 3)
+      return out, hidden
+
     if cc is None or src.shape[0] <= cc:
       out = self._stage(src, mask)
     else:
@@ -397,6 +535,99 @@ class RowInteraction(nn.Module):
     return out.reshape(b, t, -1)
 
 
+@dataclasses.dataclass
+class QuantizedTensor:
+  """Per-tensor symmetric integer quantization of a cached K or V tensor.
+
+  data holds the quantized codes; scale is the per-tensor absmax / max_val
+  factor, so the float value is data.to(dtype) * scale.
+  """
+  data: torch.Tensor
+  scale: torch.Tensor
+
+  def dequantize(self, dtype: torch.dtype) -> torch.Tensor:
+    """Dequantizes back to a floating-point tensor of the given dtype."""
+    return self.data.to(dtype) * self.scale.to(dtype)
+
+
+# Per dtype: (lo, hi, max_val) clamp range, one code below the dtype's full
+# range so -max and +max map symmetrically and dequantization cannot exceed
+# the original absmax in magnitude.
+_QUANTIZATION_RANGES: Dict[torch.dtype, Tuple[int, int, int]] = {
+    torch.int8: (-127, 127, 127),
+}
+
+
+def _quantize_tensor(t: torch.Tensor,
+                      dtype: torch.dtype = torch.int8) -> QuantizedTensor:
+  """Per-tensor symmetric integer quantization to dtype."""
+  if dtype not in _QUANTIZATION_RANGES:
+    raise ValueError(f"Unsupported quantization dtype {dtype}; supported: "
+                      f"{list(_QUANTIZATION_RANGES.keys())}")
+  lo, hi, max_val = _QUANTIZATION_RANGES[dtype]
+  absmax = t.abs().amax()
+  scale = absmax / max_val
+  # Avoid division by zero for all-zero tensors.
+  scale = torch.clamp(scale, min=torch.finfo(scale.dtype).tiny)
+  data = (t / scale).round().clamp(lo, hi).to(dtype)
+  return QuantizedTensor(data=data, scale=scale)
+
+
+def move_cache_to_device(cache, device):
+  """Recursively moves a TabFM.prefill() cache dict to device.
+
+  Handles the nested structure of the cache returned by TabFM.prefill(): a
+  dict (top-level col1/col2/icl keys), a list/tuple (per-block K/V pairs,
+  per-block induced-point hidden reprs), the ICLearningCache/QuantizedTensor
+  dataclasses, and plain tensor leaves. Needed for the
+  keep_cache_on_device=False path (CPU-offload between predict calls).
+  """
+  if isinstance(cache, torch.Tensor):
+    return cache.to(device)
+  if isinstance(cache, dict):
+    return {k: move_cache_to_device(v, device) for k, v in cache.items()}
+  if isinstance(cache, list):
+    return [move_cache_to_device(v, device) for v in cache]
+  if isinstance(cache, tuple):
+    return tuple(move_cache_to_device(v, device) for v in cache)
+  if dataclasses.is_dataclass(cache):
+    kwargs = {f.name: move_cache_to_device(getattr(cache, f.name), device)
+              for f in dataclasses.fields(cache)}
+    return type(cache)(**kwargs)
+  return cache
+
+
+@dataclasses.dataclass
+class ICLearningCache:
+  """Per-block ICL K/V cache produced at prefill and reused at decode.
+
+  layer_caches is a per-block list of (k, v) of shape [B, T_prefill, N, D],
+  each a QuantizedTensor after quantize(). prefill_train_size is the [B] count
+  of valid training rows used to build the decode attention mask; it stays
+  full precision after quantize().
+  """
+  layer_caches: List[Tuple[Any, Any]]
+  prefill_train_size: torch.Tensor
+
+  @property
+  def prefill_seq_len(self) -> int:
+    """Sequence length of the prefill cache, derived from tensor shape."""
+    k, _ = self.layer_caches[0]
+    data = k.data if isinstance(k, QuantizedTensor) else k
+    return data.shape[1]
+
+  def quantize(self, dtype: torch.dtype = torch.int8) -> "ICLearningCache":
+    """Returns a copy with the per-block ICL K/V quantized to dtype.
+
+    Only the attention K/V is quantized; prefill_train_size stays full
+    precision.
+    """
+    quantized = [(_quantize_tensor(k, dtype), _quantize_tensor(v, dtype))
+                 for k, v in self.layer_caches]
+    return ICLearningCache(layer_caches=quantized,
+                            prefill_train_size=self.prefill_train_size)
+
+
 class ICLearning(nn.Module):
   def __init__(self, d_model, num_blocks, nhead, max_classes, dim_ff,
                decoder_hidden, is_classifier=True):
@@ -411,8 +642,28 @@ class ICLearning(nn.Module):
       self.y_encoder = MLP(1, [decoder_hidden], d_model)
       self.decoder = MLP(d_model, [decoder_hidden], 1)
 
-  def forward(self, reps, y, train_size):  # reps: [B,T,d_model]
+  def forward(self, reps, y, train_size, *,
+              cache: Optional[ICLearningCache] = None,
+              return_cache: bool = False):
+    """Forward pass for ICLearning. reps: [B, T, E] row representations.
+
+    train_size is None exactly when cache is given (decode): the attention mask
+    is then derived from the cached prefill's train size and sequence length
+    rather than this call's, and y is unused. return_cache (prefill only) also
+    returns the ICLearningCache for this call alongside the decoded output.
+    """
+    assert (cache is not None) == (train_size is None), (
+        "train_size must be None iff cache is given.")
     b, t, _ = reps.shape
+
+    if cache is not None:  # Decode.
+      prefill_seq_len = cache.prefill_seq_len
+      tm_ctx = (torch.arange(prefill_seq_len, device=reps.device)[None, :]
+                < cache.prefill_train_size[:, None])
+      mask = tm_ctx[:, None, None, :]
+      out = self.tf_icl(reps, attn_mask=mask, cached_kv=cache.layer_caches)
+      return self.decoder(self.ln(out))
+
     tm = (torch.arange(t, device=reps.device)[None, :] < train_size[:, None])
     if self.is_classifier:
       y_enc = self.y_encoder(y)
@@ -420,6 +671,10 @@ class ICLearning(nn.Module):
       y_enc = self.y_encoder(y[..., None].to(reps.dtype))
     r = reps + y_enc * tm[..., None]
     mask = tm[:, None, None, :]
+    if return_cache:  # Prefill.
+      out, kvs = self.tf_icl(r, attn_mask=mask, return_kv=True)
+      new_cache = ICLearningCache(layer_caches=kvs, prefill_train_size=train_size)
+      return self.decoder(self.ln(out)), new_cache
     out = self.tf_icl(r, attn_mask=mask)
     return self.decoder(self.ln(out))
 
@@ -485,3 +740,78 @@ class TabFM(nn.Module):
     emb = self.col_embedder_2(emb, train_size)
     reps = self.row_interactor_2(emb, d=d)
     return self.icl_predictor(reps, y, train_size)
+
+  def prefill(self, x, y, cat_mask=None, d=None):
+    """Encodes context (training) rows once and returns (logits, cache).
+
+    x is [B, T, H] context rows and y is [B, T] context labels; cat_mask is an
+    optional [B, H] categorical-feature mask and d an optional [B] active-
+    feature count. Pads the sequence to a multiple of 128 with the -100
+    sentinel, derives train_size from the non-sentinel y entries, runs the full
+    pipeline while collecting the col-embedder induced-point reprs and the ICL
+    encoder per-layer K/V, and unpads the logits to the original length. cache
+    is a dict with keys 'col1', 'col2' (per-block induced-point reprs) and
+    'icl' (an ICLearningCache).
+    """
+    x = torch.nan_to_num(x, nan=-100.0).to(self.cls_tokens.dtype)
+    y = y.to(self.cls_tokens.dtype)
+
+    t_orig = x.shape[1]
+    block_size = 128
+    pad_len = ((t_orig - 1) // block_size + 1) * block_size - t_orig
+    if pad_len > 0:
+      x = F.pad(x, (0, 0, 0, pad_len), value=-100.0)
+      y = F.pad(y, (0, pad_len), value=-100.0)
+
+    # All data is training data; train_size counts non-sentinel y entries so
+    # externally-padded rows (or the padding just added above) are excluded.
+    is_valid = y != -100.0
+    train_size = is_valid.sum(dim=-1).to(torch.long)
+
+    cell = self.cell_embedder(x, y, train_size, cat_mask, d=d)
+    emb, cache_col1 = self.col_embedder(cell, train_size, return_repr=True)
+    b1, t1, _, e = emb.shape
+    cls = self.cls_tokens.expand(b1, t1, -1, -1)
+    emb = torch.cat([cls, emb], dim=2)
+    emb = self.row_interactor(emb, d=d)
+    emb, cache_col2 = self.col_embedder_2(emb, train_size, return_repr=True)
+    reps = self.row_interactor_2(emb, d=d)
+    logits, cache_icl = self.icl_predictor(reps, y, train_size, return_cache=True)
+
+    cache = {"col1": cache_col1, "col2": cache_col2, "icl": cache_icl}
+    return logits[:, :t_orig, :], cache
+
+  def decode(self, x, cache, cat_mask=None, d=None):
+    """Generates predictions for test rows using a cache from prefill.
+
+    x is [B, T, H] test rows and cache is the dict returned by prefill;
+    cat_mask and d are as in prefill. Pads to a multiple of 128, re-runs the
+    row-independent cell embedder and row interactors on the test rows, reuses
+    the cached col-embedder reprs and ICL per-layer K/V instead of recomputing
+    them from the context, and unpads to the original test length. Returns
+    [B, T, K_or_1] logits.
+    """
+    x = torch.nan_to_num(x, nan=-100.0).to(self.cls_tokens.dtype)
+    b, t_orig, _ = x.shape
+
+    block_size = 128
+    pad_len = ((t_orig - 1) // block_size + 1) * block_size - t_orig
+    if pad_len > 0:
+      x = F.pad(x, (0, 0, 0, pad_len), value=-100.0)
+
+    # y carries no information for test rows in decode (unlabeled); use the
+    # -100 sentinel throughout, matching JAX.
+    y = torch.full((b, x.shape[1]), -100.0, dtype=self.cls_tokens.dtype, device=x.device)
+    train_size_zero = torch.zeros(b, dtype=torch.long, device=x.device)
+
+    cell = self.cell_embedder(x, y, train_size_zero, cat_mask, d=d)
+    emb = self.col_embedder(cell, None, cached_repr=cache["col1"])
+    b1, t1, _, e = emb.shape
+    cls = self.cls_tokens.expand(b1, t1, -1, -1)
+    emb = torch.cat([cls, emb], dim=2)
+    emb = self.row_interactor(emb, d=d)
+    emb = self.col_embedder_2(emb, None, cached_repr=cache["col2"])
+    reps = self.row_interactor_2(emb, d=d)
+    out = self.icl_predictor(reps, y, None, cache=cache["icl"])
+
+    return out[:, :t_orig, :]

--- a/tabfm/src/pytorch/model_test.py
+++ b/tabfm/src/pytorch/model_test.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 import unittest
+
+from absl import logging
 import numpy as np
 import torch
 from flax import nnx
@@ -156,6 +158,190 @@ class PyTorchModelTest(unittest.TestCase):
             1e-4,
             f"Fidelity discrepancy found: max diff = {max_diff}, mean diff = {mean_diff} for is_classifier={is_classifier}"
         )
+
+  def _make_prefill_decode_model(self):
+    model = PyTorchTabFM.TabFM(
+        embed_dim=32,
+        max_classes=5,
+        col_num_blocks=1,
+        col_nhead=2,
+        col_num_inds=8,
+        row_num_blocks=1,
+        row_nhead=2,
+        row_num_cls=4,
+        icl_num_blocks=2,
+        icl_nhead=2,
+        ff_factor=2,
+        feature_group_size=3,
+        is_classifier=True,
+    )
+    model.eval()
+    with torch.no_grad():
+      # fourier_frequencies{,_cat} are checkpoint-loaded buffers that default
+      # to all-zero at random init, which would make the Fourier cell features
+      # (and hence every row's embedding) identically constant regardless of
+      # x -- a vacuous test. Seed them so cell embeddings genuinely depend on
+      # per-row input, matching what a real (checkpoint-loaded) model does.
+      model.cell_embedder.fourier_frequencies.normal_()
+      model.cell_embedder.fourier_frequencies_cat.normal_()
+      # per_dim_scale also defaults to all-zero; give it a small nonzero init
+      # so attention scores are not degenerate.
+      for name, p in model.named_parameters():
+        if "per_dim_scale" in name:
+          p.normal_(std=0.1)
+    return model
+
+  def test_prefill_decode_consistency(self):
+    """decode(test | prefill(context)) should match forward(concat) on test rows."""
+    torch.manual_seed(0)
+    b, t, h = 1, 20, 4
+    train_len = 10
+    max_classes = 5
+
+    model = self._make_prefill_decode_model()
+
+    x = torch.randn(b, t, h)
+    y = torch.randint(0, max_classes, (b, t)).float()
+    train_size = torch.tensor([train_len])
+
+    with torch.no_grad():
+      out_full = model(x, y, train_size)
+    out_full_test = out_full[:, train_len:, :]
+
+    x_train, y_train = x[:, :train_len, :], y[:, :train_len]
+    x_test = x[:, train_len:, :]
+
+    with torch.no_grad():
+      _, cache = model.prefill(x_train, y_train)
+      self.assertIn("col1", cache)
+      self.assertIn("col2", cache)
+      self.assertIn("icl", cache)
+      out_decode = model.decode(x_test, cache)
+
+    self.assertEqual(out_decode.shape, out_full_test.shape)
+    # Sanity check that the test data isn't in the degenerate "all rows
+    # identical" regime (which would make this parity check vacuous).
+    self.assertGreater(
+        (out_full_test[:, 0] - out_full_test[:, 1]).abs().max().item(), 1e-4
+    )
+    diff_fp32 = (out_full_test - out_decode).abs()
+    max_diff_fp32 = diff_fp32.max().item()
+    logging.info(
+        "[prefill/decode parity] fp32 max-abs-diff = %.6e", max_diff_fp32
+    )
+    # fp32 prefill/decode is algebraically exact; gate near machine precision.
+    self.assertLess(
+        max_diff_fp32, 1e-5,
+        f"fp32 prefill/decode vs full-forward diff too large: {max_diff_fp32}"
+    )
+
+    # Separately report the bf16 max-abs-diff (not gated -- bf16 has ~1e-2/1e-3
+    # relative precision, so this is diagnostic rather than a strict gate).
+    model_bf16 = self._make_prefill_decode_model()
+    model_bf16.load_state_dict(model.state_dict())
+    model_bf16 = model_bf16.to(torch.bfloat16).eval()
+
+    x_bf16 = x.to(torch.bfloat16)
+    y_bf16 = y.to(torch.bfloat16)
+    x_train_bf16, y_train_bf16 = x_bf16[:, :train_len, :], y_bf16[:, :train_len]
+    x_test_bf16 = x_bf16[:, train_len:, :]
+
+    with torch.no_grad():
+      out_full_bf16 = model_bf16(x_bf16, y_bf16, train_size)
+      out_full_test_bf16 = out_full_bf16[:, train_len:, :]
+      _, cache_bf16 = model_bf16.prefill(x_train_bf16, y_train_bf16)
+      out_decode_bf16 = model_bf16.decode(x_test_bf16, cache_bf16)
+
+    max_diff_bf16 = (
+        out_full_test_bf16.float() - out_decode_bf16.float()
+    ).abs().max().item()
+    logging.info(
+        "[prefill/decode parity] bf16 max-abs-diff = %.6e", max_diff_bf16
+    )
+
+  def test_quantized_cache_decode_consistency(self):
+    """decode() with an int8-quantized ICLearningCache stays close to fp32."""
+    torch.manual_seed(0)
+    b, t, h = 1, 20, 4
+    train_len = 10
+    max_classes = 5
+
+    model = self._make_prefill_decode_model()
+
+    x = torch.randn(b, t, h)
+    y = torch.randint(0, max_classes, (b, t)).float()
+    x_train, y_train = x[:, :train_len, :], y[:, :train_len]
+    x_test = x[:, train_len:, :]
+
+    with torch.no_grad():
+      _, cache_fp32 = model.prefill(x_train, y_train)
+      out_decode_fp32 = model.decode(x_test, cache_fp32)
+
+      icl_cache = cache_fp32["icl"]
+      quantized_icl_cache = icl_cache.quantize()
+      for (k_q, v_q) in quantized_icl_cache.layer_caches:
+        self.assertIsInstance(k_q, PyTorchTabFM.QuantizedTensor)
+        self.assertEqual(k_q.data.dtype, torch.int8)
+        self.assertIsInstance(v_q, PyTorchTabFM.QuantizedTensor)
+        self.assertEqual(v_q.data.dtype, torch.int8)
+      self.assertEqual(
+          quantized_icl_cache.prefill_seq_len, icl_cache.prefill_seq_len
+      )
+      cache_quantized = dict(cache_fp32, icl=quantized_icl_cache)
+      out_decode_quantized = model.decode(x_test, cache_quantized)
+
+    self.assertEqual(out_decode_quantized.shape, out_decode_fp32.shape)
+    max_diff = (out_decode_fp32 - out_decode_quantized).abs().max().item()
+    fp32_scale = out_decode_fp32.abs().max().item()
+    rel_diff = max_diff / (fp32_scale + 1e-12)
+    logging.info(
+        "[quantized cache] fp32-vs-int8 max-abs-diff = %.6e "
+        "(rel = %.6e of output scale %.4f)",
+        max_diff,
+        rel_diff,
+        fp32_scale,
+    )
+    # int8 is lossy; gate on relative deviation (2% >> int8's ~0.8% resolution).
+    self.assertLess(
+        rel_diff, 0.02,
+        f"int8-quantized cache decode diverged too much from fp32: "
+        f"rel={rel_diff:.3e} (abs={max_diff:.3e}, scale={fp32_scale:.3e})"
+    )
+
+  def test_quantize_unsupported_dtype_raises(self):
+    """quantize() rejects a dtype not in the registered quantization ranges."""
+    t = torch.randn(2, 3)
+    with self.assertRaises(ValueError):
+      PyTorchTabFM._quantize_tensor(t, dtype=torch.int16)
+
+  def test_move_cache_to_device_roundtrip(self):
+    """move_cache_to_device preserves values and structure (CPU roundtrip)."""
+    torch.manual_seed(0)
+    b, t, h = 1, 12, 4
+    train_len = 8
+    max_classes = 5
+    model = self._make_prefill_decode_model()
+    x = torch.randn(b, t, h)
+    y = torch.randint(0, max_classes, (b, t)).float()
+    x_train, y_train = x[:, :train_len, :], y[:, :train_len]
+    x_test = x[:, train_len:, :]
+
+    with torch.no_grad():
+      _, cache = model.prefill(x_train, y_train)
+      cache["icl"] = cache["icl"].quantize()
+      moved = PyTorchTabFM.move_cache_to_device(cache, "cpu")
+      out_direct = model.decode(x_test, cache)
+      out_moved = model.decode(x_test, moved)
+
+    self.assertTrue(torch.equal(out_direct, out_moved))
+    for (k, v), (k_m, v_m) in zip(
+        cache["icl"].layer_caches, moved["icl"].layer_caches
+    ):
+      self.assertTrue(torch.equal(k.data, k_m.data))
+      self.assertTrue(torch.equal(k.scale, k_m.scale))
+      self.assertEqual(str(k_m.data.device), "cpu")
+      self.assertTrue(torch.equal(v.data, v_m.data))
+      self.assertTrue(torch.equal(v.scale, v_m.scale))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Scope

This PR adds in-context caching to the PyTorch backend, opt-in via
`cache_context=True` on `TabFMClassifier` / `TabFMRegressor` (default: `False`).
When it's on, two options control the cache's memory footprint:

- `maybe_quantize_kv_cache` (default: `True`): int8-quantize the ICL KV cache to
  reduce memory; set `False` to keep the cache full precision.
- `keep_cache_on_device` (default: `True`): caches stay on GPU by default; with
  `False`, they are stored on CPU between prediction calls.

> This PR implements the JAX backend's prefill/decode cache path for PyTorch and
> exposes it through `cache_context=True`. The unquantized cached path matches
> uncached predictions within fp32 tolerance; the default int8 KV cache reduces
> memory, with numerical impact measured in the benchmark below.

I also ran a benchmark on Adult (OpenML 1590) for throughput and accuracy; results
are in the Benchmark section.

## Usage

The following block shows the usage example.

```python
## Classifier
...
clf = TabFMClassifier(
    model=model,
    cache_context=True,
    maybe_quantize_kv_cache=True,   # int8-quantize the cached KV
    keep_cache_on_device=True,      # False stores cache on CPU between predict calls
)
clf.fit(X_train, y_train)

predictions = clf.predict(X_test)
probabilities = clf.predict_proba(X_test)

## Regressor
...
reg = TabFMRegressor(
    model=model,
    cache_context=True,
    maybe_quantize_kv_cache=True,
    keep_cache_on_device=True,
)
reg.fit(X_train, y_train)
predictions = reg.predict(X_test)
```

## Benchmark

I benchmarked context caching on Adult (OpenML 1590), a binary classification
task: predict whether annual income is > 50K or <= 50K. I used the following
setup:

- **Dataset split:** 10,000 (stratified) for context, 38,842 for test.
- **Inference batch:** 2,000 test samples per prediction call (unrelated to the
  `batch_size` parameter, which sets the number of ensemble members per forward).
- **Model dtype:** bf16 for the throughput and accuracy runs. Cached and uncached
  run at the same precision, so any difference is the cache alone.
- **Cache config:** `keep_cache_on_device=True`, so all members' caches are kept on
  the GPU (not offloaded to CPU).
- **Unquantized fp32 check:** a separate run at fp32 precision (2,000 context,
  2,000 test, n_estimators=2), where rounding is negligible, to check the cached
  and uncached paths produce the same result.
- **Hardware:** NVIDIA L4 (24 GB VRAM).
- **Metrics measured:**
  - throughput (rows/s)
  - ROC-AUC
  - max|p_cached - p_uncached|: the largest change between the cached and
    uncached runs in the predicted probability of the > 50K class.
  - peak GPU memory

The following table summarizes the bf16 runs.

| n_estimators | path | rows/s | speedup | ROC-AUC | max\|p_cached - p_uncached\| | peak GPU |
|-------------:|------|-------:|--------:|--------:|-----------------------------:|---------:|
| 4 | uncached | 118 | 1.0x | 0.9289 | N/A | 4.5 GB |
| 4 | cached + int8 | 912 | 7.8x | 0.9289 | 1.9e-2 | 11.4 GB |
| 8 | uncached | 59 | 1.0x | 0.9289 | N/A | 4.5 GB |
| 8 | cached + int8 | 457 | 7.8x | 0.9289 | 1.3e-2 | 15.4 GB |

**Observations:**

- **Throughput:** cached is ~7.8x over uncached at both n_estimators (4 and 8).
- **Accuracy and numerical differences:**
  - ROC-AUC is unchanged across all runs.
  - default int8 cache: max|p_cached - p_uncached| is ~1.9e-2 in the bf16
    model run, with no observed effect on ROC-AUC.
  - fp32 unquantized cache: max|p_cached - p_uncached| = 3.7e-6, within the
    1e-5 tolerance used for comparing cached vs uncached predictions.
- **Memory:** cached peak grows with n_estimators (11.4 GB at 4, 15.4 GB at 8) because
  all members' caches are kept on the GPU at once; uncached stays at 4.5 GB.

<details>
<summary><strong>Changelog</strong></summary>

- **`tabfm/src/pytorch/model.py`**
  - Added `prefill()` / `decode()` to `TabFM`: encode the context once and reuse
    it during prediction.
  - Added optional cache arguments to the attention modules (`MultiheadAttention`,
    `MultiheadAttentionBlock`, `Encoder`, `InducedSelfAttentionBlock`,
    `SetTransformer`, `ColEmbedding`, `ICLearning`) so `decode()` reuses the
    cached KV instead of recomputing it.
  - Added the int8 KV-cache path: `QuantizedTensor`, `_quantize_tensor`,
    `ICLearningCache.quantize()`, `move_cache_to_device`. Only the ICL KV is
    quantized; column representations and training row counts stay full
    precision.
- **`tabfm/src/classifier_and_regressor.py`**
  - Added `cache_context`, `maybe_quantize_kv_cache`, `keep_cache_on_device` to
    both estimators. `fit()` builds the per-member cache; prediction uses
    `decode()` with the cached context. JAX raises `NotImplementedError`.
  - Added train-only / test-only tensor builders for the decode path:
    `transform_context_only`, `transform_test_only`, `prepare_test_tensors`.
- **`tabfm/src/pytorch/__init__.py`**
  - Added the package init.
- **`tabfm/src/pytorch/model_test.py`**
  - Added coverage that the cached path (`prefill` + `decode`) gives the same
    test-row output logits as the uncached full forward pass: max absolute
    difference <= 1e-5 in fp32; bf16 difference is reported for reference.
  - Added an int8-cache vs fp32-cache test that checks quantization error stays
    within tolerance (2% relative, observed 0.34%).
  - Added tests that an unsupported quantization dtype is rejected and that the
    cache is preserved after a device swap.
- **`tabfm/src/classifier_and_regressor_pytorch_test.py`**
  - Added cached-vs-uncached classifier/regressor tests with cache quantization
    disabled.

</details>

> Disclaimer: Claude was used to understand/read the repo and author changes. However, the changes were supervised and were reviewed afterwards. The benchmarks were also run to evaluate the impact on accuracy.
