### PR TITLE
Cast float64 targets before moving them to the device

### DIFF
--- a/tabfm/src/classifier_and_regressor.py
+++ b/tabfm/src/classifier_and_regressor.py
@@ -1977,9 +1977,10 @@ def _predict_step_pytorch(
   device = next(model.parameters()).device
 
   X_t = torch.from_numpy(X_batch).to(device, dtype=torch.float32)
-  y_t = torch.from_numpy(y_batch).to(device)
+  y_t = torch.from_numpy(y_batch)
   if y_t.dtype == torch.float64:
     y_t = y_t.to(torch.float32)
+  y_t = y_t.to(device)
 
   batch_size = X_batch.shape[0]
   train_size_t = torch.full(

--- a/tabfm/src/classifier_and_regressor.py
+++ b/tabfm/src/classifier_and_regressor.py
@@ -2065,9 +2065,10 @@ def _build_context_cache_pytorch(
         Xs_split, ys_split, cat_masks_split, ds_split
     ):
       X_t = torch.from_numpy(X_batch).to(device, dtype=torch.float32)
-      y_t = torch.from_numpy(y_batch).to(device)
+      y_t = torch.from_numpy(y_batch)
       if y_t.dtype == torch.float64:
         y_t = y_t.to(torch.float32)
+      y_t = y_t.to(device)
       cat_mask_t = torch.from_numpy(cat_mask_batch).to(device)
       d_t = torch.from_numpy(ds_batch).to(device)
       _, cache = model.prefill(X_t, y_t, cat_mask=cat_mask_t, d=d_t)

--- a/tabfm/src/classifier_and_regressor_pytorch_test.py
+++ b/tabfm/src/classifier_and_regressor_pytorch_test.py
@@ -136,6 +136,29 @@ class PyTorchClassifierRegressorTest(unittest.TestCase):
     self.assertEqual(preds_cached.shape, (10,))
     np.testing.assert_allclose(preds_cached, preds, rtol=1e-5, atol=1e-6)
 
+  def test_regressor_batch_forward_float64_targets_on_mps(self):
+    if not torch.backends.mps.is_available():
+      self.skipTest("MPS is required for this test.")
+
+    class _Model(torch.nn.Module):
+
+      def __init__(self):
+        super().__init__()
+        self.anchor = torch.nn.Parameter(torch.zeros((), device="mps"))
+
+      def forward(self, X, y, train_size, cat_mask=None, d=None):
+        del X, train_size, cat_mask, d
+        return y.unsqueeze(-1) + self.anchor
+
+    reg = TabFMRegressor(model=_Model(), batch_size=1)
+    X = np.zeros((1, 2, 1), dtype=np.float32)
+    y = np.zeros((1, 1), dtype=np.float64)
+
+    preds = reg._batch_forward(X, y)
+
+    self.assertEqual(preds.dtype, np.float32)
+    np.testing.assert_array_equal(preds, [[[-100.0]]])
+
 
 class PyTorchModelPickleTest(unittest.TestCase):
   """The PyTorch model must be picklable.

--- a/tabfm/src/classifier_and_regressor_pytorch_test.py
+++ b/tabfm/src/classifier_and_regressor_pytorch_test.py
@@ -159,6 +159,47 @@ class PyTorchClassifierRegressorTest(unittest.TestCase):
     self.assertEqual(preds.dtype, np.float32)
     np.testing.assert_array_equal(preds, [[[-100.0]]])
 
+  def test_regressor_context_cache_float64_targets_on_mps(self):
+    if not torch.backends.mps.is_available():
+      self.skipTest("MPS is required for this test.")
+
+    np.random.seed(42)
+    model = pytorch_model.TabFM(
+        embed_dim=8,
+        max_classes=1,
+        col_num_blocks=1,
+        col_nhead=2,
+        col_num_inds=8,
+        row_num_blocks=1,
+        row_nhead=2,
+        row_num_cls=2,
+        icl_num_blocks=1,
+        icl_nhead=2,
+        ff_factor=2,
+        feature_group_size=2,
+        is_classifier=False,
+    ).to("mps")
+
+    reg = TabFMRegressor(
+        model=model,
+        n_estimators=2,
+        batch_size=2,
+        random_state=42,
+        cache_context=True,
+        maybe_quantize_kv_cache=False,
+    )
+
+    X = np.random.rand(10, 3)
+    # numpy's default float dtype is float64, which MPS cannot hold.
+    y = np.random.rand(10)
+
+    # The context prefill runs inside fit(), so the dtype crash lands here.
+    reg.fit(X, y)
+
+    preds = reg.predict(X)
+    self.assertEqual(preds.shape, (10,))
+    self.assertTrue(np.all(np.isfinite(preds)))
+
 
 class PyTorchModelPickleTest(unittest.TestCase):
   """The PyTorch model must be picklable.


### PR DESCRIPTION
Fixes #68.

`_predict_step_pytorch` moved `y` to the model device before casting float64 down to float32. MPS does not support float64, so the move itself raised:

```
TypeError: Cannot convert a MPS Tensor to float64 dtype as the MPS framework
doesn't support float64. Please use float32 instead.
```

numpy's default float dtype is float64, so an ordinary float target array triggers this on any Apple Silicon host. `X_t` already fuses the cast into its own `.to(device, dtype=torch.float32)`; only `y` was affected.

This does the existing conditional cast on the CPU tensor and moves afterwards. The cast stays conditional on purpose: classifier targets are encoded as int64 and regressor scaling can yield float16, so casting unconditionally would silently change those dtypes.

Adds a regression test that drives the real `_batch_forward` path with float64 targets on a model whose parameters live on MPS. It fails with the TypeError above against the previous ordering, and passes with the fix.

One note on the test: it skips when MPS is unavailable, so it will skip on CI runners without an Apple GPU. The crash only reproduces on that backend - on CPU the old and new orderings are indistinguishable, since `.to("cpu")` accepts float64 and the later cast then fixes it. A CPU-only test would pass against the broken code, so it would not be a real guard. Happy to change the approach if you would prefer something else here.
