### PR TITLE
Fix regressor fit crash when sklearn output is globally set to pandas

### DIFF
--- a/tabfm/src/classifier_and_regressor.py
+++ b/tabfm/src/classifier_and_regressor.py
@@ -3430,6 +3430,7 @@ class TabFMRegressor(RegressorMixin, BaseEstimator):
     cat_features = list(range(n_cat))
 
     self.y_scaler_ = StandardScaler()
+    self.y_scaler_.set_output(transform="default")
     y = self.y_scaler_.fit_transform(y.reshape(-1, 1)).flatten()
 
     self.ensemble_generator_ = EnsembleGenerator(


### PR DESCRIPTION
### Problem

`TabFMRegressor.fit` scales the regression target with a `StandardScaler` and then calls `.flatten()` on the transformed result. When a user has `sklearn.set_config(transform_output="pandas")` set globally (common in analysis notebooks), `fit_transform` returns a pandas `DataFrame`, which has no `.flatten()` method, so fitting fails with:

```
AttributeError: 'DataFrame' object has no attribute 'flatten'
```

This is issue #58 (regression example not working).

### Fix

Pin the target scaler to numpy output via `set_output(transform="default")`, so target scaling is unaffected by the user's global sklearn output configuration.

Note: only this site needs the change. The classifier's `CategoricalOrdinalEncoder` path is not affected (that encoder is never wrapped to pandas output), and `inverse_transform` calls are never wrapped either, so no other sites required a fix.

### Testing

- Reproduced the `AttributeError` on the regressor fit path with `transform_output="pandas"` before the change, and confirmed `fit` completes cleanly after it.
- The non-JAX unit tests in `classifier_and_regressor_test` pass locally.
