### PR TITLE
Fix dtype of empty feature shuffle patterns

### DIFF
--- a/tabfm/src/classifier_and_regressor.py
+++ b/tabfm/src/classifier_and_regressor.py
@@ -898,7 +898,7 @@ class FeatureShuffler:
           f"Unknown method: {self.method}. Use 'random' or 'none'."
       )
 
-    return [np.array(p) for p in shuffle_patterns]
+    return [np.asarray(p, dtype=np.intp) for p in shuffle_patterns]
 
 
 class PreprocessingPipeline(TransformerMixin, BaseEstimator):


### PR DESCRIPTION
## Problem

Thx for open-sourcing TabFM — really appreciate the work!

While running TabFM on the KC1 dataset with an n-shot retrieved context, `predict_proba` crashes with:

```text
IndexError: arrays used as indices must be of integer (or boolean) type
```

The relevant traceback is:

```text
File "tabfm/src/classifier_and_regressor.py", line 1630, in _transform_features
    shuffled_cols = X_variant_instance[:, shuffle_pattern]
IndexError: arrays used as indices must be of integer (or boolean) type
```

The shuffle patterns are converted with:

```python
return [np.array(p) for p in shuffle_patterns]
```

When `p` is empty, NumPy infers `float64`. The resulting array is later used for column indexing, which requires an integer or boolean dtype.

## Fix

Convert shuffle patterns using NumPy's native indexing dtype:

```diff
- return [np.array(p) for p in shuffle_patterns]
+ return [np.asarray(p, dtype=np.intp) for p in shuffle_patterns]
```

This preserves the values and ordering of non-empty patterns while making empty patterns valid NumPy index arrays.

## Reproduce

```python
import numpy as np

shuffle_pattern = np.array([])
X = np.empty((3, 0))

print(shuffle_pattern.dtype)  # float64
X[:, shuffle_pattern]         # IndexError before this change
```

After this change:

```python
shuffle_pattern = np.asarray([], dtype=np.intp)
X = np.empty((3, 0))

result = X[:, shuffle_pattern]
print(result.shape)  # (3, 0)
```

## Test

Ran the existing classifier and regressor tests:

```text
pytest -q tabfm/src/classifier_and_regressor_test.py

18 passed, 28 skipped in 3.06s
```
