### PR TITLE
Fix encoded_missing_value being ignored and all-missing datetime columns crashing

### DIFF
--- a/tabfm/src/classifier_and_regressor.py
+++ b/tabfm/src/classifier_and_regressor.py
@@ -242,7 +242,9 @@ class CategoricalOrdinalEncoder(BaseEstimator, TransformerMixin):
     for i in range(n_features):
       col = X[:, i]
       cats = self.categories_[i]
-      valid_mask = col != self.unknown_value
+      valid_mask = (col != self.unknown_value) & (
+          col != self.encoded_missing_value
+      )
       if np.any(valid_mask):
         indices = col[valid_mask].astype(int)
         X_out[valid_mask, i] = cats[indices]

--- a/tabfm/src/classifier_and_regressor.py
+++ b/tabfm/src/classifier_and_regressor.py
@@ -337,7 +337,10 @@ class DatetimeTransformer(BaseEstimator, TransformerMixin):
       series = pd.to_datetime(
           X.iloc[:, pos], utc=True, errors="coerce", format="mixed"
       )
-      self._fillna_map[pos] = series.mean()
+      fillna_value = series.mean()
+      if pd.isna(fillna_value):
+        fillna_value = pd.Timestamp(0, tz="UTC")
+      self._fillna_map[pos] = fillna_value
     return self
 
   def transform(self, X: Any) -> np.ndarray:

--- a/tabfm/src/classifier_and_regressor.py
+++ b/tabfm/src/classifier_and_regressor.py
@@ -208,6 +208,7 @@ class CategoricalOrdinalEncoder(BaseEstimator, TransformerMixin):
 
     for i in range(n_features):
       col = X[:, i]
+      missing_mask = pd.isna(col)
       cats = self.categories_[i]
       cat_to_idx = {c: idx for idx, c in enumerate(cats)}
       mapped = pd.Series(col).map(cat_to_idx)
@@ -216,7 +217,9 @@ class CategoricalOrdinalEncoder(BaseEstimator, TransformerMixin):
       if mapped.dtype.name == "category":
         mapped = mapped.astype(object)
 
-      # Fill NaNs/Unknowns with unknown_value
+      mapped.loc[missing_mask] = self.encoded_missing_value
+
+      # Fill unknowns with unknown_value
       X_out[:, i] = mapped.fillna(self.unknown_value).values.astype(self.dtype)
 
     return X_out

--- a/tabfm/src/classifier_and_regressor_test.py
+++ b/tabfm/src/classifier_and_regressor_test.py
@@ -27,6 +27,7 @@ try:
 except ImportError:
   HAS_JAX = False
 from tabfm.src.classifier_and_regressor import _looks_like_datetime
+from tabfm.src.classifier_and_regressor import CategoricalOrdinalEncoder
 from tabfm.src.classifier_and_regressor import EnsembleGenerator
 from tabfm.src.classifier_and_regressor import TabFMClassifier
 from tabfm.src.classifier_and_regressor import TabFMRegressor
@@ -1163,6 +1164,21 @@ class DatetimeDetectionTest(absltest.TestCase):
             "k", "l", "m", "2020-01-01", "2021-05-02"]  # 2/20 = 10% dates
     self.assertFalse(_looks_like_datetime(pd.Series(vals, dtype=object)))
     self.assertFalse(_looks_like_datetime(pd.Series(vals, dtype="string")))
+
+
+class CategoricalOrdinalEncoderTest(absltest.TestCase):
+
+  def test_missing_and_unknown_values_are_encoded_separately(self):
+    encoder = CategoricalOrdinalEncoder(
+        unknown_value=-1, encoded_missing_value=-99
+    )
+    encoder.fit(np.array([["known"], ["other"]], dtype=object))
+
+    encoded = encoder.transform(
+        np.array([[np.nan], ["unseen"], ["known"]], dtype=object)
+    )
+
+    np.testing.assert_array_equal(encoded[:, 0], [-99, -1, 0])
 
 
 class ColumnNameRobustnessTest(absltest.TestCase):

--- a/tabfm/src/classifier_and_regressor_test.py
+++ b/tabfm/src/classifier_and_regressor_test.py
@@ -28,6 +28,7 @@ except ImportError:
   HAS_JAX = False
 from tabfm.src.classifier_and_regressor import _looks_like_datetime
 from tabfm.src.classifier_and_regressor import CategoricalOrdinalEncoder
+from tabfm.src.classifier_and_regressor import DatetimeTransformer
 from tabfm.src.classifier_and_regressor import EnsembleGenerator
 from tabfm.src.classifier_and_regressor import TabFMClassifier
 from tabfm.src.classifier_and_regressor import TabFMRegressor
@@ -1179,6 +1180,17 @@ class CategoricalOrdinalEncoderTest(absltest.TestCase):
     )
 
     np.testing.assert_array_equal(encoded[:, 0], [-99, -1, 0])
+
+
+class DatetimeTransformerTest(absltest.TestCase):
+
+  def test_all_missing_column_uses_epoch_fill_value(self):
+    X = pd.DataFrame({"ts": pd.to_datetime([None, None, None])})
+
+    transformed = DatetimeTransformer().fit_transform(X)
+
+    self.assertEqual(transformed.shape, (3, 5))
+    self.assertTrue(np.isfinite(transformed).all())
 
 
 class ColumnNameRobustnessTest(absltest.TestCase):

--- a/tabfm/src/classifier_and_regressor_test.py
+++ b/tabfm/src/classifier_and_regressor_test.py
@@ -1181,6 +1181,18 @@ class CategoricalOrdinalEncoderTest(absltest.TestCase):
 
     np.testing.assert_array_equal(encoded[:, 0], [-99, -1, 0])
 
+  def test_inverse_transform_does_not_decode_the_missing_sentinel(self):
+    encoder = CategoricalOrdinalEncoder(
+        unknown_value=-1, encoded_missing_value=-99
+    )
+    encoder.fit(np.array([["known"], ["other"]], dtype=object))
+
+    decoded = encoder.inverse_transform(np.array([[-99], [-1], [0]]))
+
+    self.assertIsNone(decoded[0, 0])
+    self.assertIsNone(decoded[1, 0])
+    self.assertEqual(decoded[2, 0], "known")
+
 
 class DatetimeTransformerTest(absltest.TestCase):
 


### PR DESCRIPTION
Two independent edge case fixes in `tabfm/src/classifier_and_regressor.py`, one per commit.

## 1. `CategoricalOrdinalEncoder` ignores `encoded_missing_value`

`encoded_missing_value` is accepted in `__init__` and documented as "Encoded value used for NaN / missing values", but `transform()` never reads it. Missing values and unseen categories are both filled with `unknown_value`, so the parameter has no effect.

```python
enc = CategoricalOrdinalEncoder(unknown_value=-1, encoded_missing_value=-99)
enc.fit(np.array([["known"], ["other"]], dtype=object))
enc.transform(np.array([[np.nan], ["unseen"], ["known"]], dtype=object))
# before: [-1., -1., 0.]
# after:  [-99., -1., 0.]
```

The fix records the original NaN positions before mapping and fills those with `encoded_missing_value`, leaving `unknown_value` for values genuinely absent from the category map. Both parameters default to `-1`, so behaviour is unchanged unless a caller sets them differently.

## 2. `DatetimeTransformer` crashes on an all-missing datetime column

`fit()` stores `series.mean()` as the fill value. For a column with no valid timestamps that mean is `NaT`, so the later `fillna` is a no-op and the subsequent `.astype(np.int64)` on the extracted parts raises:

```python
DatetimeTransformer().fit_transform(pd.DataFrame({"ts": pd.to_datetime([None, None, None])}))
# before: pandas.errors.IntCastingNaNError: Cannot convert non-finite values (NA or inf) to integer
# after:  completes, shape (3, 5), all values finite
```

The fix falls back to the epoch when the computed mean is `NaT`. Columns with at least one valid timestamp are unaffected.

## Tests

Added `CategoricalOrdinalEncoderTest` and `DatetimeTransformerTest` to `classifier_and_regressor_test.py`. Both were confirmed to fail against the unpatched source (`-1.0` vs `-99` for the first, `IntCastingNaNError` for the second) and pass with the change.

Full existing suite after the change: 48 tests run, 20 passed, 28 skipped because JAX is not installed in my environment. Those 28 remain unverified locally.

These changes do not touch any line modified by my open PRs #59 or #69.