### PR TITLE
Resolve the Hugging Face token from HF_TOKEN or a stored login

### DIFF
--- a/tabfm/src/hugging_face/convert_and_upload.py
+++ b/tabfm/src/hugging_face/convert_and_upload.py
@@ -68,7 +68,10 @@ flags.DEFINE_string(
 flags.DEFINE_string(
     "token",
     None,
-    "Hugging Face write token. Required if repo_id is provided.",
+    "Hugging Face write token. Prefer the HF_TOKEN environment variable or "
+    "`hf auth login`: a token passed on the command line is visible to other "
+    "users on the machine through the process list. Required if repo_id is "
+    "provided and neither of those is set.",
 )
 flags.DEFINE_string(
     "checkpoint_path",
@@ -188,11 +191,19 @@ def main(argv):
     local_dirs[mtype] = saved_dir
     
   if FLAGS.repo_id:
-    if not FLAGS.token:
-      raise ValueError("Hugging Face token is required when repo_id is provided.")
+    from huggingface_hub import HfApi, get_token  # pylint: disable=g-import-not-at-top
 
-    from huggingface_hub import HfApi  # pylint: disable=g-import-not-at-top
-    api = HfApi(token=FLAGS.token)
+    # get_token() reads HF_TOKEN and then the token saved by `hf auth login`,
+    # so the credential does not have to be passed in argv, where it stays
+    # visible to every other user on the machine for the life of the upload.
+    token = FLAGS.token or get_token()
+    if not token:
+      raise ValueError(
+          "Hugging Face token is required when repo_id is provided. Set "
+          "HF_TOKEN, run `hf auth login`, or pass --token."
+      )
+
+    api = HfApi(token=token)
 
     for mtype, sdir in local_dirs.items():
       logging.info("Uploading %s folder to %s...", mtype, FLAGS.repo_id)


### PR DESCRIPTION
While reading the Hugging Face upload utility I noticed that `--token` is mandatory whenever `--repo_id` is set:

https://github.com/google-research/tabfm/blob/b15593e4c1111ddb5f4f30dd2957df2edbaa04ca/tabfm/src/hugging_face/convert_and_upload.py#L191-L195

So the only way to run an upload today is to put a write-scoped Hugging Face token into the command line. On Linux `/proc/<pid>/cmdline` is world-readable, which means any other user on the machine can read that token out of `ps` for as long as the run lasts, and it is left behind in shell history. A conversion followed by an upload is not a quick command, so the window is not a small one.

`huggingface_hub` already handles this. Its exported `get_token()` resolves `HF_TOKEN`, then the token saved by `hf auth login`, and in CI an OIDC token via Trusted Publishers. It is present in the pinned `huggingface-hub==1.21.0`.

This change falls back to `get_token()` only when `--token` is not passed, so anyone already passing the flag sees no change — the flag still wins. The error message now names all three ways to supply a credential, and the flag's help text explains why the environment variable is the better default.

What I checked, and what I could not: the file parses, and `get_token` is exported by huggingface_hub 1.21.0. I could not exercise the upload end to end, because that needs write access to `google/tabfm-1.0.0-pytorch`.

If you would rather keep the hard requirement on the flag, I am happy to close this — it is your call.

Disclosure: I used an AI assistant to help find and prepare this change. I have reviewed and verified it myself.
