### PR TITLE
Fix PyTorch-only import without JAX

### DIFF
--- a/tabfm/src/classifier_and_regressor.py
+++ b/tabfm/src/classifier_and_regressor.py
@@ -3037,8 +3037,9 @@ class TabFMClassifier(ClassifierMixin, BaseEstimator):
   def _predict_oof_proba(
       self, cv: int = 5
   ) -> tuple[
-    jt.Float[jt.Array | np.ndarray, "E N K"],
-    Optional[jt.Int[jt.Array | np.ndarray, "V"]]]:
+    jt.Float[Array | np.ndarray, "E N K"],
+    Optional[jt.Int[Array | np.ndarray, "V"]],
+  ]:
     """Perform out-of-fold predictions on some or all training samples.
 
     Predictions are either made using cross-validation, a single train/val
@@ -3957,8 +3958,9 @@ class TabFMRegressor(RegressorMixin, BaseEstimator):
       self,
       cv: int = 5,
   ) -> tuple[
-    jt.Float[jt.Array | np.ndarray, "E N"],
-    Optional[jt.Int[jt.Array | np.ndarray, "V"]]]:
+    jt.Float[Array | np.ndarray, "E N"],
+    Optional[jt.Int[Array | np.ndarray, "V"]],
+  ]:
     """Perform out-of-fold predictions on some or all training samples.
 
     Predictions are either made using cross-validation, a single train/val


### PR DESCRIPTION
## Summary

Fixes an import error when TabFM is installed with the PyTorch-only backend without JAX.

Four type annotations still referenced `jt.Array`, even though the module already defines an `Array` fallback to `np.ndarray` when JAX is unavailable.

Before the fix:

```text
AttributeError: module 'jaxtyping' has no attribute 'Array'